### PR TITLE
Ntndcodec

### DIFF
--- a/ImageJ/EPICS_areaDetector/NTNDCodec.java
+++ b/ImageJ/EPICS_areaDetector/NTNDCodec.java
@@ -132,7 +132,7 @@ public class NTNDCodec
             } else if (scalarType==ScalarType.pvShort) {
                 short temp[] = myUtil.byteBufferToShortArray(decompressOutBuffer);
                 BasePVShortArray pvArray = new BasePVShortArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("shortValue", pvArray);
             } else if (scalarType==ScalarType.pvUShort) {
                 short temp[] = myUtil.byteBufferToShortArray(decompressOutBuffer);

--- a/ImageJ/EPICS_areaDetector/NTNDCodec.java
+++ b/ImageJ/EPICS_areaDetector/NTNDCodec.java
@@ -121,13 +121,13 @@ public class NTNDCodec
                 byte[] temp = new byte[numElements];
                 decompressOutBuffer.get(temp);
                 BasePVByteArray pvArray = new BasePVByteArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("byteValue", pvArray);
             } else if (scalarType==ScalarType.pvUByte) {            
                 byte[] temp = new byte[numElements];
                 decompressOutBuffer.get(temp);
                 BasePVUByteArray pvArray = new BasePVUByteArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("ubyteValue", pvArray);
             } else if (scalarType==ScalarType.pvShort) {
                 short temp[] = myUtil.byteBufferToShortArray(decompressOutBuffer);
@@ -137,27 +137,27 @@ public class NTNDCodec
             } else if (scalarType==ScalarType.pvUShort) {
                 short temp[] = myUtil.byteBufferToShortArray(decompressOutBuffer);
                 BasePVUShortArray pvArray = new BasePVUShortArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("ushortValue", pvArray);
             } else if (scalarType==ScalarType.pvInt) {
                 int temp[] = myUtil.byteBufferToIntArray(decompressOutBuffer);
                 BasePVIntArray pvArray = new BasePVIntArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("intValue", pvArray);
             } else if (scalarType==ScalarType.pvUInt) {
                 int temp[] = myUtil.byteBufferToIntArray(decompressOutBuffer);
                 BasePVUIntArray pvArray = new BasePVUIntArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("uintValue", pvArray);
             } else if (scalarType==ScalarType.pvFloat) {
                 float temp[] = myUtil.byteBufferToFloatArray(decompressOutBuffer);
                 BasePVFloatArray pvArray = new BasePVFloatArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("floatValue", pvArray);
             } else if (scalarType==ScalarType.pvDouble) {
                 double temp[] = myUtil.byteBufferToDoubleArray(decompressOutBuffer);
                 BasePVDoubleArray pvArray = new BasePVDoubleArray(new BaseScalarArray(scalarType));
-                pvArray.put(0, numElements, temp, 0);
+                pvArray.shareData(temp);
                 pvUnionValue.set("doubleValue", pvArray);
             }
 


### PR DESCRIPTION
I have replaced the copy with a call to directly set the underlying array for the BasePVXXXArray, the prepared temp array is simply used as the data array.
Based on the code I don't ssee any risk of the array reference being leaked to any other thread so this should be safe way to eliminate an additional copy.

@brunoseivam @mrkraimer @MarkRivers it would still be best to test this change before merging.
