### PR TITLE
EPICS_NTNDA_Viewer:  PVA channelname from environment

### DIFF
--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -127,7 +127,12 @@ public class EPICS_NTNDA_Viewer
      */
     public EPICS_NTNDA_Viewer()
     {
+        String temp=null;
         readProperties();
+        temp = System.getenv("EPICS_NTNDA_VIEWER_CHANNELNAME");
+        if (temp != null) {
+            channelName = temp;
+        }
         createAndShowGUI();
     }
     /* (non-Javadoc)


### PR DESCRIPTION
Adding the ability to read the default PVA channelname from an environment variable named `EPICS_NTNDA_VIEWER_CHANNELNAME`. This will override the channelname, potentially read from the .properties file.

The behaviour is unchanged if the environment variable is not set.

This enables starting imagej from the command-line (or EDM button for a specific application) and not require the user to manually type the PVA channel name into the plugins input field.