### PR TITLE
FIX: Parse ColorMode as PVScalar.

### DIFF
--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -42,6 +42,7 @@ import org.epics.pvaClient.PvaClientMonitorData;
 import org.epics.pvdata.factory.ConvertFactory;
 import org.epics.pvdata.pv.Convert;
 import org.epics.pvdata.pv.PVInt;
+import org.epics.pvdata.pv.PVScalar;
 import org.epics.pvdata.pv.PVScalarArray;
 import org.epics.pvdata.pv.PVString;
 import org.epics.pvdata.pv.PVStructure;
@@ -380,12 +381,12 @@ public class EPICS_NTNDA_Viewer
                 if(!name.equals("ColorMode")) continue;
                 PVUnion pvUnion = pvAttr.getSubField(PVUnion.class,"value");
                 if(pvUnion==null) continue;
-                PVInt pvcm = pvUnion.get(PVInt.class);
+                PVScalar pvcm = pvUnion.get(PVScalar.class);
                 if(pvcm==null) {
-                    logMessage("color mode is not an int",true,true);
+                    logMessage("color mode is not a PVScalar",true,true);
                     continue;
                 }
-                cm = pvcm.get();
+                cm = ConvertFactory.getConvert().toInt(pvcm);
                 break;
             }
         }


### PR DESCRIPTION
This PR changes the way ColorMode is parsed using the PVScalar and invoking the Convert class to fetch an int value for it.

Recently while playing with some generated NTNDArray and ImageJ I noticed that it was giving me a warning that ColorMode was not an integer. Looking at my structure the ColorMode attribute value was set as `long`.
With this PR any numeric value that can be casted to an int can be used and visualization goes without warnings.

Note: I am fixing my issue downstream so my data is generated with an int value at the ColorMode but I thought it would be good to also have this change here.