### PR TITLE
Formatting the Python viewers

### DIFF
--- a/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -24,7 +24,7 @@ import os
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
-class NTNDA_Channel_Provider(object):
+class NTNDA_Channel_Provider:
     """
     Base class for monitoring an NTNDArray channel from an areaDetector IOC.
     The methods are called by NTNDA_Viewer.
@@ -484,7 +484,7 @@ class ImageControl(QWidget):
         self.imageDisplay.show()
 
 
-class FindLibrary(object):
+class FindLibrary:
     def __init__(self, parent=None):
         self.save = {}
 

--- a/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -9,19 +9,19 @@ author Marty Kraimer
     original development started 2019.12
 """
 
-import sys, time, signal
-
-signal.signal(signal.SIGINT, signal.SIG_DFL)
+import time
+import signal
 import numpy as np
 from pyqtgraph.widgets.RawImageWidget import RawImageWidget
 from PyQt5.QtWidgets import QWidget, QLabel, QLineEdit, QSlider
 from PyQt5.QtWidgets import QPushButton, QHBoxLayout, QGridLayout
 from PyQt5.QtWidgets import QRubberBand
 from PyQt5.QtCore import *
-
 import ctypes
 import ctypes.util
 import os
+
+signal.signal(signal.SIGINT, signal.SIG_DFL)
 
 
 class NTNDA_Channel_Provider(object):
@@ -118,7 +118,7 @@ class ImageControl(QWidget):
         self.imageDisplay = Image_Display()
         self.imageDisplay.clientReleaseEvent(self.clientReleaseEvent)
         self.imageDict = imageDictCreate()
-        self.pixelLevels = (int(0), int(255))
+        self.pixelLevels = (0, 255)
         self.npixelLevels = 255
         self.minimum = 0;
         self.low = 0
@@ -175,6 +175,7 @@ class ImageControl(QWidget):
         self.resetButton = QPushButton("reset")
         self.resetButton.setEnabled(True)
         self.resetButton.clicked.connect(self.resetEvent)
+        self.resetButton.resize(self.resetButton.sizeHint())
         self.zoomText = QLineEdit()
         self.zoomText.setEnabled(True)
         self.zoomText.setFixedWidth(180)
@@ -432,26 +433,25 @@ class ImageControl(QWidget):
             self.imageDict["dtype"] = imageDict["dtype"]
             dtype = self.imageDict["dtype"]
             if dtype == str("int8"):
-                self.pixelLevels = (int(-128), int(127))
+                self.pixelLevels = (-128, 127)
             elif dtype == str("uint8"):
-                self.pixelLevels = (int(0), int(255))
+                self.pixelLevels = (0, 255)
             elif dtype == str("int16"):
-                self.pixelLevels = (int(-32768), int(32767))
+                self.pixelLevels = (-32768, 32767)
             elif dtype == str("uint16"):
-                self.pixelLevels = (int(0), int(65536))
+                self.pixelLevels = (0, 65536)
             elif dtype == str("int32"):
-                self.pixelLevels = (int(-2147483648), int(2147483647))
+                self.pixelLevels = (-2147483648, 2147483647)
             elif dtype == str("uint32"):
-                self.pixelLevels = (int(0), int(4294967296))
+                self.pixelLevels = (0, 4294967296)
             elif dtype == str("int64"):
-                self.pixelLevels = (
-                int(-9223372036854775808), int(9223372036854775807))
+                self.pixelLevels = (-9223372036854775808, 9223372036854775807)
             elif dtype == str("uint64"):
-                self.pixelLevels = (int(0), int(18446744073709551615))
+                self.pixelLevels = (0, 18446744073709551615)
             elif dtype == str("float32"):
-                self.pixelLevels = (float(0.0), float(1.0))
+                self.pixelLevels = (0.0, 1.0)
             elif dtype == str("float64"):
-                self.pixelLevels = (float(0.0), float(1.0))
+                self.pixelLevels = (0.0, 1.0)
             else:
                 raise Exception("unknown dtype" + dtype)
                 return
@@ -517,10 +517,6 @@ class NTNDA_Viewer(QWidget):
         self.stopButton.setEnabled(False)
         self.stopButton.clicked.connect(self.stopEvent)
         self.stopButton.resize(self.stopButton.sizeHint())
-        if len(self.provider.getChannelName()) < 1:
-            name = os.getenv("EPICS_NTNDA_VIEWER_CHANNELNAME")
-            if name:
-                self.provider.setChannelName(name)
         self.nImages = 0
         self.imageRateText = QLabel()
         self.imageRateText.setFixedWidth(40)
@@ -738,25 +734,35 @@ class NTNDA_Viewer(QWidget):
             self.codecNameText.setText(self.codecName)
         typevalue = codec["parameters"]
         if typevalue == 1:
-            dtype = "int8"; elementsize = int(1)
+            dtype = "int8"
+            elementsize = 1
         elif typevalue == 5:
-            dtype = "uint8"; elementsize = int(1)
+            dtype = "uint8"
+            elementsize = 1
         elif typevalue == 2:
-            dtype = "int16"; elementsize = int(2)
+            dtype = "int16"
+            elementsize = 2
         elif typevalue == 6:
-            dtype = "uint16"; elementsize = int(2)
+            dtype = "uint16"
+            elementsize = 2
         elif typevalue == 3:
-            dtype = "int32"; elementsize = int(4)
+            dtype = "int32"
+            elementsize = 4
         elif typevalue == 7:
-            dtype = "uint32"; elementsize = int(4)
+            dtype = "uint32"
+            elementsize = 4
         elif typevalue == 4:
-            dtype = "int64"; elementsize = int(8)
+            dtype = "int64"
+            elementsize = 8
         elif typevalue == 8:
-            dtype = "uint64"; elementsize = int(8)
+            dtype = "uint64"
+            elementsize = 8
         elif typevalue == 9:
-            dtype = "float32"; elementsize = int(4)
+            dtype = "float32"
+            elementsize = 4
         elif typevalue == 10:
-            dtype = "float64"; elementsize = int(8)
+            dtype = "float64"
+            elementsize = 8
         else:
             raise Exception("decompress mapIntToType failed")
         if codecName == "blosc":
@@ -768,8 +774,7 @@ class NTNDA_Viewer(QWidget):
         else:
             lib = None
         if lib is None:
-            raise Exception(
-            "shared library " + codecName + " not found")
+            raise Exception("shared library " + codecName + " not found")
         self.imageDict["dtype"] = dtype
         self.dtypeText.setText(str(self.imageDict["dtype"]))
         inarray = bytearray(data)
@@ -793,7 +798,7 @@ class NTNDA_Viewer(QWidget):
                 in_char_array.from_buffer(inarray),
                 out_char_array.from_buffer(outarray),
                 int(uncompressed / elementsize),
-                elementsize, int(0))
+                elementsize, 0)
             data = np.array(outarray)
             data = np.frombuffer(data, dtype=dtype)
         elif codecName == "jpeg":

--- a/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -1,5 +1,5 @@
 # NTNDA_Viewer.py
-'''
+"""
 Copyright - See the COPYRIGHT that is included with this distribution.
     NTNDA_Viewer is distributed subject to a Software License Agreement found
     in file LICENSE that is included with this distribution.
@@ -7,14 +7,15 @@ Copyright - See the COPYRIGHT that is included with this distribution.
 author Marty Kraimer
     latest date 2020.03.02
     original development started 2019.12
-'''
+"""
 
-import sys,time,signal
+import sys, time, signal
+
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 import numpy as np
 from pyqtgraph.widgets.RawImageWidget import RawImageWidget
-from PyQt5.QtWidgets import QWidget,QLabel,QLineEdit,QSlider
-from PyQt5.QtWidgets import QPushButton,QHBoxLayout,QGridLayout
+from PyQt5.QtWidgets import QWidget, QLabel, QLineEdit, QSlider
+from PyQt5.QtWidgets import QPushButton, QHBoxLayout, QGridLayout
 from PyQt5.QtWidgets import QRubberBand
 from PyQt5.QtCore import *
 
@@ -22,90 +23,102 @@ import ctypes
 import ctypes.util
 import os
 
-class NTNDA_Channel_Provider(object) :
-    '''
+
+class NTNDA_Channel_Provider(object):
+    """
     Base class for monitoring an NTNDArray channel from an areaDetector IOC.
     The methods are called by NTNDA_Viewer.
-    '''
+    """
 
-    def __init__(self) :
+    def __init__(self):
         self.channelName = None
-    def setChannelName(self,channelName) :
+
+    def setChannelName(self, channelName):
         self.channelName = channelName
-    def getChannelName(self) :
+
+    def getChannelName(self):
         return self.channelName
-    def start(self) :
-        ''' called to start monitoring.'''
-        raise Exception('derived class must implement NTNDA_Channel_Provider.start')
-    def stop(self) :
-        ''' called to stop monitoring.'''
-        raise Exception('derived class must implement NTNDA_Channel_Provider.stop')
-    def done(self) :
-        ''' called when NTNDA_Viewer is done.'''
+
+    def start(self):
+        """Called to start monitoring."""
+        raise Exception(
+            'derived class must implement NTNDA_Channel_Provider.start')
+
+    def stop(self):
+        """Called to stop monitoring."""
+        raise Exception(
+            'derived class must implement NTNDA_Channel_Provider.stop')
+
+    def done(self):
+        """Called when NTNDA_Viewer is done."""
         pass
-    def callback(self,arg) :
-        ''' must call NTNDA_Viewer.callback(arg).'''
-        raise Exception('derived class must implement NTNDA_Channel_Provider.callback')
+
+    def callback(self, arg):
+        """Must call NTNDA_Viewer.callback(arg)."""
+        raise Exception(
+            'derived class must implement NTNDA_Channel_Provider.callback')
 
 
-def imageDictCreate() :
-    return {"image" : None , "dtype" : "" , "nx" : 0 , "ny" : 0 ,  "nz" : 0 }
+def imageDictCreate():
+    return {"image": None, "dtype": "", "nx": 0, "ny": 0, "nz": 0}
 
-class Image_Display(RawImageWidget,QWidget) :
-    def __init__(self,parent=None, **kargs):
-        RawImageWidget.__init__(self, parent=parent,scaled=True)
+
+class Image_Display(RawImageWidget, QWidget):
+    def __init__(self, parent=None, **kargs):
+        RawImageWidget.__init__(self, parent=parent, scaled=True)
         super(QWidget, self).__init__(parent)
         self.setWindowTitle("image")
-        self.rubberBand = QRubberBand(QRubberBand.Rectangle,self)
-        self.mousePressPosition = QPoint(0,0)
-        self.mouseReleasePosition = QPoint(0,0)
+        self.rubberBand = QRubberBand(QRubberBand.Rectangle, self)
+        self.mousePressPosition = QPoint(0, 0)
+        self.mouseReleasePosition = QPoint(0, 0)
         self.clientCallback = None
         self.mousePressed = False
         self.okToClose = False
         self.setGeometry(QRect(10, 300, 600, 600))
 
-    def closeEvent(self,event) :
-        if not self.okToClose :
+    def closeEvent(self, event):
+        if not self.okToClose:
             self.hide()
             return
 
-    def display(self,image,pixelLevels) :
-        self.setImage(image,levels=pixelLevels)
+    def display(self, image, pixelLevels):
+        self.setImage(image, levels=pixelLevels)
         self.show()
 
-    def mousePressEvent(self,event) :
+    def mousePressEvent(self, event):
         self.mousePressPosition = QPoint(event.pos())
-        self.rubberBand.setGeometry(QRect(self.mousePressPosition,QSize()))
+        self.rubberBand.setGeometry(QRect(self.mousePressPosition, QSize()))
         self.rubberBand.show()
         self.mousePressed = True
 
-    def mouseMoveEvent(self,event) :
-        if not self.mousePressed : return
-        self.rubberBand.setGeometry(QRect(self.mousePressPosition,event.pos()).normalized())
+    def mouseMoveEvent(self, event):
+        if not self.mousePressed: return
+        self.rubberBand.setGeometry(
+            QRect(self.mousePressPosition, event.pos()).normalized())
 
-    def mouseReleaseEvent(self,event) :
-        if not self.mousePressed : return
+    def mouseReleaseEvent(self, event):
+        if not self.mousePressed: return
         self.mouseReleasePosition = QPoint(event.pos())
-        if not self.clientCallback==None : 
-            self.clientCallback(self.mousePressPosition,self.mouseReleasePosition)
+        if not self.clientCallback == None:
+            self.clientCallback(self.mousePressPosition,
+                                self.mouseReleasePosition)
         self.rubberBand.hide()
         self.mousePressed = False
 
-    def clientReleaseEvent(self,clientCallback) :
+    def clientReleaseEvent(self, clientCallback):
         self.clientCallback = clientCallback
 
 
+class ImageControl(QWidget):
 
-class ImageControl(QWidget) :
-
-    def __init__(self,statusText,parent=None, **kargs):
+    def __init__(self, statusText, parent=None, **kargs):
         super(QWidget, self).__init__(parent)
         self.isClosed = False
         self.statusText = statusText
         self.imageDisplay = Image_Display()
         self.imageDisplay.clientReleaseEvent(self.clientReleaseEvent)
         self.imageDict = imageDictCreate()
-        self.pixelLevels = (int(0),int(255))
+        self.pixelLevels = (int(0), int(255))
         self.npixelLevels = 255
         self.minimum = 0;
         self.low = 0
@@ -117,7 +130,7 @@ class ImageControl(QWidget) :
         self.ylow = 0
         self.numx = 0
         self.numy = 0
-# first row
+        # first row
         minimumLabel = QLabel("minimum")
         minimumLabel.setFixedWidth(100)
         lowLabel = QLabel("low")
@@ -130,17 +143,17 @@ class ImageControl(QWidget) :
         maximumLabel.setFixedWidth(80)
         zoomLabel = QLabel('||    zoom        (xlow,ylow,numx.numy)')
         box = QHBoxLayout()
-        box.setContentsMargins(0,0,0,0);
+        box.setContentsMargins(0, 0, 0, 0);
         box.addWidget(minimumLabel)
         box.addWidget(lowLabel);
         box.addWidget(titleLabel);
         box.addWidget(highLabel);
         box.addWidget(maximumLabel)
         box.addWidget(zoomLabel)
-        wid =  QWidget()
+        wid = QWidget()
         wid.setLayout(box)
         self.firstRow = wid
-#second row
+        # second row
         self.minimumText = QLineEdit()
         self.minimumText.setText('')
         self.minimumText.setEnabled(True)
@@ -168,7 +181,7 @@ class ImageControl(QWidget) :
         self.zoomText.setFixedWidth(180)
         self.zoomText.editingFinished.connect(self.zoomTextEvent)
         box = QHBoxLayout()
-        box.setContentsMargins(0,0,0,0);
+        box.setContentsMargins(0, 0, 0, 0);
         box.addWidget(self.minimumText)
         box.addWidget(self.lowText)
         box.addWidget(spaceLabel)
@@ -177,12 +190,12 @@ class ImageControl(QWidget) :
         box.addWidget(dividerLabel)
         box.addWidget(self.resetButton)
         box.addWidget(self.zoomText)
-        wid =  QWidget()
+        wid = QWidget()
         wid.setLayout(box)
         self.secondRow = wid
-#third row
+        # third row
         self.lowSlider = QSlider(Qt.Horizontal)
-        self.lowSlider.setContentsMargins(0,0,0,0);
+        self.lowSlider.setContentsMargins(0, 0, 0, 0);
         self.lowSlider.setMinimum(0)
         self.lowSlider.setMaximum(self.npixelLevels)
         self.lowSlider.setValue(0)
@@ -190,7 +203,7 @@ class ImageControl(QWidget) :
         self.lowSlider.setTickInterval(10)
         self.lowSlider.setFixedWidth(256)
         self.highSlider = QSlider(Qt.Horizontal)
-        self.highSlider.setContentsMargins(0,0,0,0);
+        self.highSlider.setContentsMargins(0, 0, 0, 0);
         self.highSlider.setMinimum(0)
         self.highSlider.setMaximum(self.npixelLevels)
         self.highSlider.setValue(self.npixelLevels)
@@ -200,25 +213,25 @@ class ImageControl(QWidget) :
         box = QHBoxLayout()
         box.addStretch(0)
         box.setSpacing(0);
-        box.setContentsMargins(0,0,0,0);
+        box.setContentsMargins(0, 0, 0, 0);
         box.setGeometry(QRect(0, 0, 500, 20))
         box.addWidget(self.lowSlider)
         box.addWidget(self.highSlider)
-        wid =  QWidget()
+        wid = QWidget()
         wid.setLayout(box)
         self.thirdRow = wid
-#create window
+        # create window
         layout = QGridLayout()
         layout.setSpacing(0);
-        layout.addWidget(self.firstRow,0,0,alignment=Qt.AlignLeft)
-        layout.addWidget(self.secondRow,1,0,alignment=Qt.AlignLeft)
-        layout.addWidget(self.thirdRow,2,0,alignment=Qt.AlignLeft)
+        layout.addWidget(self.firstRow, 0, 0, alignment=Qt.AlignLeft)
+        layout.addWidget(self.secondRow, 1, 0, alignment=Qt.AlignLeft)
+        layout.addWidget(self.thirdRow, 2, 0, alignment=Qt.AlignLeft)
         self.setLayout(layout)
         self.lowSlider.valueChanged.connect(self.lowSliderValueChange)
         self.highSlider.valueChanged.connect(self.highSliderValueChange)
         self.show()
 
-    def resetEvent(self) :
+    def resetEvent(self):
         self.xlow = 0
         self.ylow = 0
         self.numx = self.imageDict["nx"]
@@ -226,9 +239,9 @@ class ImageControl(QWidget) :
         zoom = '(0,0,' + str(self.numx) + ',' + str(self.numy) + ')'
         self.zoomText.setText(zoom)
         self.isZoomImage = False
-        self.imageDisplay.display(self.imageDict["image"],self.pixelLevels)
+        self.imageDisplay.display(self.imageDict["image"], self.pixelLevels)
 
-    def clientReleaseEvent(self,pressPosition,releasePosition) :
+    def clientReleaseEvent(self, pressPosition, releasePosition):
         qrect = self.imageDisplay.geometry()
         height = qrect.height()
         width = qrect.width()
@@ -236,68 +249,75 @@ class ImageControl(QWidget) :
         ymin = pressPosition.y()
         xmax = releasePosition.x()
         ymax = releasePosition.y()
-        if xmin==xmax and ymin>=ymax : return
-        if xmin>=xmax or ymin>=ymax :
+        if xmin == xmax and ymin >= ymax: return
+        if xmin >= xmax or ymin >= ymax:
             self.statusText.setText('illegal mouse move')
             return
-        if self.isZoomImage : 
+        if self.isZoomImage:
             xstart = self.xlow
             ystart = self.ylow
             sizex = self.numx
             sizey = self.numy
-        else :
+        else:
             xstart = 0
             ystart = 0
             sizex = self.imageDict["nx"]
             sizey = self.imageDict["ny"]
-        if (sizex/sizey)>1.0 :
-            yfact = sizex/sizey
+        if (sizex / sizey) > 1.0:
+            yfact = sizex / sizey
             xfact = 1.0
-        elif (sizey/sizex)>1.0 :
+        elif (sizey / sizex) > 1.0:
             yfact = 1.0
-            xfact = sizey/sizex
-        else :
+            xfact = sizey / sizex
+        else:
             yfact = 1.0
             xfact = 1.0
-        ratiox = (sizex/width)*xfact
-        ratioy = (sizey/height)*yfact
-        xlow = int(xmin*ratiox) + self.xlow
-        ylow = int(ymin*ratioy) + self.ylow
-        numx = int((xmax-xmin)*ratiox)
-        numy = int((ymax-ymin)*ratioy)       
-        zoom = '(' + str(xlow) + ',' + str(ylow) + ',' + str(numx) + ',' + str(numy) + ')'
+        ratiox = (sizex / width) * xfact
+        ratioy = (sizey / height) * yfact
+        xlow = int(xmin * ratiox) + self.xlow
+        ylow = int(ymin * ratioy) + self.ylow
+        numx = int((xmax - xmin) * ratiox)
+        numy = int((ymax - ymin) * ratioy)
+        zoom = '(' + str(xlow) + ',' + str(ylow) + ',' + str(numx) + ',' + str(
+            numy) + ')'
         self.zoomText.setText(zoom)
         self.zoomTextEvent()
 
-    def zoomTextEvent(self) :
-        try :
+    def zoomTextEvent(self):
+        try:
             text = self.zoomText.text()
             ind = text.find('(')
-            if ind<0 : raise Exception('does not start with (')
-            text = text[(ind+1):]
+            if ind < 0: raise Exception('does not start with (')
+            text = text[(ind + 1):]
             ind = text.find(')')
-            if ind<0 : raise Exception('does not end with )')
+            if ind < 0: raise Exception('does not end with )')
             text = text[:-1]
             split = text.split(',')
-            if len(split)!=4 : raise Exception('not four values')
+            if len(split) != 4: raise Exception('not four values')
             xlow = split[0]
-            if not xlow.isdigit() : raise Exception('xlow is not a positive integer')
+            if not xlow.isdigit(): raise Exception(
+                'xlow is not a positive integer')
             xlow = int(xlow)
             ylow = split[1]
-            if not ylow.isdigit() : raise Exception('ylow is not a positive integer')
+            if not ylow.isdigit(): raise Exception(
+                'ylow is not a positive integer')
             ylow = int(ylow)
             numx = split[2]
-            if not numx.isdigit() : raise Exception('numx is not a positive integer')
+            if not numx.isdigit(): raise Exception(
+                'numx is not a positive integer')
             numx = int(numx)
-            if numx<1 : raise Exception('numx must be at least 1')
+            if numx < 1: raise Exception('numx must be at least 1')
             numy = split[3]
-            if not numy.isdigit() : raise Exception('numy is not a positive integer')
+            if not numy.isdigit(): raise Exception(
+                'numy is not a positive integer')
             numy = int(numy)
-            if numy<1 : raise Exception('numy must be at least 1')
+            if numy < 1: raise Exception('numy must be at least 1')
             sizex = xlow + numx
-            if sizex>self.imageDict["nx"] : raise Exception('xlow + numx gt nx')
+            if sizex > self.imageDict["nx"]: raise Exception(
+                'xlow + numx gt nx')
             sizey = ylow + numy
-            if sizey>self.imageDict["ny"] : raise Exception('ylow + numy gt ny')
+            if sizey > self.imageDict["ny"]: raise Exception(
+                'ylow + numy gt ny')
         except Exception as error:
             self.statusText.setText(str(error))
             self.statusText.setStyleSheet("background-color:red")
@@ -309,163 +329,186 @@ class ImageControl(QWidget) :
         self.isZoomImage = True
         self.displayZoom()
 
-    def displayZoom(self) :
+    def displayZoom(self):
         fromimage = self.imageDict["image"]
-        if self.imageDict["nz"]==1 :
-            image = np.empty((self.numx,self.numy),dtype=self.imageDict["dtype"])
-            for indx in range(0,self.numx) :
-                for indy in range(0,self.numy) :
-                    image[indx][indy] = fromimage[indx+self.xlow][indy+self.ylow]
-        elif self.imageDict["nz"]==3 :
-            image = np.empty((self.numx,self.numy,3),dtype=self.imageDict["dtype"])
-            for indx in range(0,self.numx) :
-                for indy in range(0,self.numy) :
-                    for indz in range(0,3) :
-                        image[indx][indy][indz] = fromimage[indx+self.xlow][indy+self.ylow][indz]
-        else : raise Exception('ndim not 2 or 3')
-        self.imageDisplay.display(image,self.pixelLevels)
+        if self.imageDict["nz"] == 1:
+            image = np.empty((self.numx, self.numy),
+                             dtype=self.imageDict["dtype"])
+            for indx in range(0, self.numx):
+                for indy in range(0, self.numy):
+                    image[indx][indy] = fromimage[indx + self.xlow][
+                        indy + self.ylow]
+        elif self.imageDict["nz"] == 3:
+            image = np.empty((self.numx, self.numy, 3),
+                             dtype=self.imageDict["dtype"])
+            for indx in range(0, self.numx):
+                for indy in range(0, self.numy):
+                    for indz in range(0, 3):
+                        image[indx][indy][indz] = \
+                        fromimage[indx + self.xlow][indy + self.ylow][indz]
+        else:
+            raise Exception('ndim not 2 or 3')
+        self.imageDisplay.display(image, self.pixelLevels)
         self.imageDisplay.show()
 
-    def minimumEvent(self) :
+    def minimumEvent(self):
         try:
             minimum = float(self.minimumText.text())
-            if minimum>self.maximum :
+            if minimum > self.maximum:
                 minimum = self.maximum
                 self.minimumText.setText(str(minimum))
             self.minimum = minimum
             self.low = minimum
             self.lowText.setText(str(self.low))
-            self.pixelLevels = (self.low,self.high)
+            self.pixelLevels = (self.low, self.high)
             self.lowSlider.setValue(0)
-            if self.isZoomImage : self.displayZoom()
-            else :self.imageDisplay.display(self.imageDict["image"],self.pixelLevels)
+            if self.isZoomImage:
+                self.displayZoom()
+            else:
+                self.imageDisplay.display(self.imageDict["image"],
+                                          self.pixelLevels)
         except Exception as error:
             self.minimumText.setText(str(error))
 
-    def maximumEvent(self) :
+    def maximumEvent(self):
         try:
             maximum = float(self.maximumText.text())
-            if maximum<self.minimum :
+            if maximum < self.minimum:
                 maximum = self.minimum
                 self.maximumText.setText(str(maximum))
             self.maximum = maximum
             self.high = maximum
             self.highText.setText(str(self.high))
-            self.pixelLevels = (self.low,self.high)
+            self.pixelLevels = (self.low, self.high)
             self.highSlider.setValue(self.npixelLevels)
-            if self.isZoomImage : self.displayZoom()
-            else :self.imageDisplay.display(self.imageDict["image"],self.pixelLevels)
+            if self.isZoomImage:
+                self.displayZoom()
+            else:
+                self.imageDisplay.display(self.imageDict["image"],
+                                          self.pixelLevels)
         except Exception as error:
             self.maximumText.setText(str(error))
 
-    def lowSliderValueChange(self) :
-        pixelRatio = float(self.lowSlider.value())/float(self.npixelLevels)
+    def lowSliderValueChange(self):
+        pixelRatio = float(self.lowSlider.value()) / float(self.npixelLevels)
         valueRange = float(self.maximum) - float(self.minimum)
-        value = pixelRatio*valueRange + self.minimum
-        if value>self.maximum : value = self.maximum
-        if value>self.high :
+        value = pixelRatio * valueRange + self.minimum
+        if value > self.maximum: value = self.maximum
+        if value > self.high:
             self.high = value
             self.highText.setText(str(round(self.high)))
             self.highSlider.setValue(self.high)
-        self.low= value
+        self.low = value
         self.lowText.setText(str(round(self.low)))
-        self.pixelLevels = (self.low,self.high)
-        if self.isZoomImage : self.displayZoom()
-        else :self.imageDisplay.display(self.imageDict["image"],self.pixelLevels)
-        
-    def highSliderValueChange(self) :
-        pixelRatio = float(self.highSlider.value())/float(self.npixelLevels)
+        self.pixelLevels = (self.low, self.high)
+        if self.isZoomImage:
+            self.displayZoom()
+        else:
+            self.imageDisplay.display(self.imageDict["image"], self.pixelLevels)
+
+    def highSliderValueChange(self):
+        pixelRatio = float(self.highSlider.value()) / float(self.npixelLevels)
         valueRange = float(self.maximum) - float(self.minimum)
-        value = pixelRatio*valueRange + self.minimum
-        if value<self.minimum : value = self.minimum
-        if value<self.low :
+        value = pixelRatio * valueRange + self.minimum
+        if value < self.minimum: value = self.minimum
+        if value < self.low:
             self.low = value
             self.lowText.setText(str(round(self.low)))
             self.lowSlider.setValue(self.low)
         self.high = value
         self.highText.setText(str(round(self.high)))
-        self.pixelLevels = (self.low,self.high)
-        if self.isZoomImage : self.displayZoom()
-        else :self.imageDisplay.display(self.imageDict["image"],self.pixelLevels)
+        self.pixelLevels = (self.low, self.high)
+        if self.isZoomImage:
+            self.displayZoom()
+        else:
+            self.imageDisplay.display(self.imageDict["image"], self.pixelLevels)
 
-    def newImage(self,imageDict):
-        if self.isClosed : return
+    def newImage(self, imageDict):
+        if self.isClosed: return
         self.imageDict["image"] = imageDict["image"]
         self.imageDict["nx"] = imageDict["nx"]
         self.imageDict["ny"] = imageDict["ny"]
         self.imageDict["nz"] = imageDict["nz"]
-        if not str(imageDict["dtype"])==str(self.imageDict["dtype"]) :
+        if not str(imageDict["dtype"]) == str(self.imageDict["dtype"]):
             self.imageDict["dtype"] = imageDict["dtype"]
             dtype = self.imageDict["dtype"]
-            if dtype==str("int8") :
-                self.pixelLevels = (int(-128),int(127))
-            elif dtype==str("uint8") :
-                self.pixelLevels = (int(0),int(255))
-            elif dtype==str("int16") :
-                self.pixelLevels = (int(-32768),int(32767))
-            elif dtype==str("uint16") :
-                self.pixelLevels = (int(0),int(65536))
-            elif dtype==str("int32") :
-                self.pixelLevels = (int(-2147483648),int(2147483647))
-            elif dtype==str("uint32") :
-                self.pixelLevels = (int(0),int(4294967296))
-            elif dtype==str("int64") :
-                self.pixelLevels = (int(-9223372036854775808),int(9223372036854775807))
-            elif dtype==str("uint64") :
-                self.pixelLevels = (int(0),int(18446744073709551615))
-            elif dtype==str("float32") :
-                self.pixelLevels = (float(0.0),float(1.0))
-            elif dtype==str("float64") :
-                self.pixelLevels = (float(0.0),float(1.0))
-            else :
+            if dtype == str("int8"):
+                self.pixelLevels = (int(-128), int(127))
+            elif dtype == str("uint8"):
+                self.pixelLevels = (int(0), int(255))
+            elif dtype == str("int16"):
+                self.pixelLevels = (int(-32768), int(32767))
+            elif dtype == str("uint16"):
+                self.pixelLevels = (int(0), int(65536))
+            elif dtype == str("int32"):
+                self.pixelLevels = (int(-2147483648), int(2147483647))
+            elif dtype == str("uint32"):
+                self.pixelLevels = (int(0), int(4294967296))
+            elif dtype == str("int64"):
+                self.pixelLevels = (
+                int(-9223372036854775808), int(9223372036854775807))
+            elif dtype == str("uint64"):
+                self.pixelLevels = (int(0), int(18446744073709551615))
+            elif dtype == str("float32"):
+                self.pixelLevels = (float(0.0), float(1.0))
+            elif dtype == str("float64"):
+                self.pixelLevels = (float(0.0), float(1.0))
+            else:
                 raise Exception('unknown dtype' + dtype)
                 return
             self.minimum = self.pixelLevels[0]
             self.minimumText.setText(str(self.minimum))
             self.low = self.minimum
             self.lowText.setText(str(self.low))
-            self.maximum  = self.pixelLevels[1]
+            self.maximum = self.pixelLevels[1]
             self.maximumText.setText(str(self.maximum))
             self.high = self.maximum
             self.highText.setText(str(self.high))
             self.lowSlider.setValue(0)
             self.highSlider.setValue(self.npixelLevels)
-            zoom = '(0,0,' + str(self.imageDict["nx"]) + ',' + str(self.imageDict["ny"]) + ')'
+            zoom = '(0,0,' + str(self.imageDict["nx"]) + ',' + str(
+                self.imageDict["ny"]) + ')'
             self.zoomText.setText(zoom)
             self.isZoomImage = False
 
-    def display(self) :
-        if self.isClosed : return
-        if self.isZoomImage :
+    def display(self):
+        if self.isClosed: return
+        if self.isZoomImage:
             self.displayZoom()
             return
-        self.imageDisplay.display(self.imageDict["image"],self.pixelLevels)
+        self.imageDisplay.display(self.imageDict["image"], self.pixelLevels)
         self.imageDisplay.show()
-          
-class FindLibrary(object) :
+
+
+class FindLibrary(object):
     def __init__(self, parent=None):
-        self.save = dict()
-    def find(self,name) :
+        self.save = {}
+
+    def find(self, name):
         lib = self.save.get(name)
-        if lib!=None : return lib
+        if lib is not None:
+            return lib
         result = ctypes.util.find_library(name)
-        if result==None : return None
+        if not result:
+            return None
         if os.name == 'nt':
             lib = ctypes.windll.LoadLibrary(result)
-        else :
+        else:
             lib = ctypes.cdll.LoadLibrary(result)
-        if lib!=None : self.save.update({name : lib})
+        if lib is None:
+            self.save.update({name: lib})
         return lib
 
-class NTNDA_Viewer(QWidget) :
-    def __init__(self,ntnda_Channel_Provider,providerName, parent=None):
+
+class NTNDA_Viewer(QWidget):
+    def __init__(self, ntnda_Channel_Provider, providerName, parent=None):
         super(QWidget, self).__init__(parent)
         self.isClosed = False
         self.provider = ntnda_Channel_Provider
         self.provider.NTNDA_Viewer = self
         self.setWindowTitle(providerName + "_NTNDA_Viewer")
         self.imageDict = imageDictCreate()
-# first row
+        # first row
         self.startButton = QPushButton('start')
         self.startButton.setEnabled(True)
         self.startButton.clicked.connect(self.startEvent)
@@ -475,9 +518,10 @@ class NTNDA_Viewer(QWidget) :
         self.stopButton.setEnabled(False)
         self.stopButton.clicked.connect(self.stopEvent)
         self.stopButton.setFixedWidth(40)
-        if len(self.provider.getChannelName())<1 :
+        if len(self.provider.getChannelName()) < 1:
             name = os.getenv('EPICS_NTNDA_VIEWER_CHANNELNAME')
-            if name!= None : self.provider.setChannelName(name)
+            if name:
+                self.provider.setChannelName(name)
         self.nImages = 0
         self.imageRateText = QLabel()
         self.imageRateText.setFixedWidth(40)
@@ -487,7 +531,7 @@ class NTNDA_Viewer(QWidget) :
         self.channelNameText.setText(self.provider.getChannelName())
         self.channelNameText.editingFinished.connect(self.channelNameEvent)
         box = QHBoxLayout()
-        box.setContentsMargins(0,0,0,0);
+        box.setContentsMargins(0, 0, 0, 0);
         box.addWidget(self.startButton)
         box.addWidget(self.stopButton)
         imageRateLabel = QLabel("imageRate:")
@@ -495,10 +539,10 @@ class NTNDA_Viewer(QWidget) :
         box.addWidget(self.imageRateText)
         box.addWidget(self.channelNameLabel)
         box.addWidget(self.channelNameText)
-        wid =  QWidget()
+        wid = QWidget()
         wid.setLayout(box)
         self.firstRow = wid
-# second row
+        # second row
         self.nxText = QLabel()
         self.nxText.setFixedWidth(50)
         self.nyText = QLabel()
@@ -524,7 +568,7 @@ class NTNDA_Viewer(QWidget) :
         self.statusText.setText('nothing done so far')
         self.statusText.setFixedWidth(200)
         box = QHBoxLayout()
-        box.setContentsMargins(0,0,0,0);
+        box.setContentsMargins(0, 0, 0, 0);
         nxLabel = QLabel("nx:")
         nxLabel.setFixedWidth(20)
         self.nxText.setText('0')
@@ -555,27 +599,27 @@ class NTNDA_Viewer(QWidget) :
         statusLabel.setFixedWidth(50)
         box.addWidget(statusLabel)
         box.addWidget(self.statusText)
-        wid =  QWidget()
+        wid = QWidget()
         wid.setLayout(box)
         self.secondRow = wid
-# third row
+        # third row
         self.imageControl = ImageControl(self.statusText)
         box = QHBoxLayout()
-        box.setContentsMargins(0,0,0,0);
+        box.setContentsMargins(0, 0, 0, 0);
         box.addWidget(self.imageControl)
-        wid =  QWidget()
+        wid = QWidget()
         wid.setLayout(box)
         self.thirdRow = wid
-# initialize
+        # initialize
         layout = QGridLayout()
         layout.setVerticalSpacing(0);
-        layout.addWidget(self.firstRow,0,0)
-        layout.addWidget(self.secondRow,1,0)
-        layout.addWidget(self.thirdRow,2,0)
+        layout.addWidget(self.firstRow, 0, 0)
+        layout.addWidget(self.secondRow, 1, 0)
+        layout.addWidget(self.thirdRow, 2, 0)
         self.setLayout(layout)
         self.findLibrary = FindLibrary()
         self.subscription = None
-        self.lasttime = time.time() -2
+        self.lasttime = time.time() - 2
         self.maxsize = 800
         self.minsize = 16
         self.width = self.maxsize
@@ -584,31 +628,31 @@ class NTNDA_Viewer(QWidget) :
         self.show()
         self.imageControl.show()
 
-    def closeEvent(self, event) :
-        if self.isStarted : self.stop()
+    def closeEvent(self, event):
+        if self.isStarted: self.stop()
         self.isClosed = True
         self.imageControl.isClosed = True
         self.provider.done()
         self.imageControl.imageDisplay.okToClose = True
         self.imageControl.imageDisplay.close()
 
-    def startEvent(self) :
+    def startEvent(self):
         self.start()
 
-    def stopEvent(self) :
+    def stopEvent(self):
         self.stop()
 
-    def clearEvent(self) :
+    def clearEvent(self):
         self.statusText.setText('')
         self.statusText.setStyleSheet("background-color:white")
-    
-    def channelNameEvent(self) :
+
+    def channelNameEvent(self):
         try:
             self.provider.setChannelName(self.channelNameText.text())
         except Exception as error:
             self.statusText.setText(str(error))
 
-    def start(self) :
+    def start(self):
         self.provider.start()
         self.channelNameText.setEnabled(False)
         self.isStarted = True
@@ -616,7 +660,7 @@ class NTNDA_Viewer(QWidget) :
         self.stopButton.setEnabled(True)
         self.channelNameText.setEnabled(False)
 
-    def stop(self) :
+    def stop(self):
         self.provider.stop()
         self.startButton.setEnabled(True)
         self.stopButton.setEnabled(False)
@@ -625,24 +669,25 @@ class NTNDA_Viewer(QWidget) :
         self.channel = None
         self.isStarted = False
 
-    def callback(self,arg):
-        if self.isClosed : return
-        if len(arg)==1 :
+    def callback(self, arg):
+        if self.isClosed: return
+        if len(arg) == 1:
             value = arg.get("exception")
-            if value!=None :
-                self.statusText.setText(str(error))
+            if value is not None:
+                self.statusText.setText(str(value))
                 return
             value = arg.get("status")
-            if value!=None :
-                if value=="disconnected" :
+            if value is not None:
+                if value == "disconnected":
                     self.channelNameLabel.setStyleSheet("background-color:red")
                     self.statusText.setText('disconnected')
                     return
-                elif value=="connected" :
-                    self.channelNameLabel.setStyleSheet("background-color:green")
+                elif value == "connected":
+                    self.channelNameLabel.setStyleSheet(
+                        "background-color:green")
                     self.statusText.setText('connected')
                     return
-                else :
+                else:
                     self.statusText.setText("unknown callback error")
                     return
         try:
@@ -657,24 +702,24 @@ class NTNDA_Viewer(QWidget) :
             self.statusText.setText(str(error))
             return
         ndim = len(dimArray)
-        if ndim!=2 and ndim!=3 :
+        if ndim != 2 and ndim != 3:
             self.statusText.setText('ndim not 2 or 3')
             return
-        if codecNameLength == 0 : 
+        if codecNameLength == 0:
             codecName = 'none'
-            if codecName!=self.codecName : 
+            if codecName != self.codecName:
                 self.codecName = codecName
                 self.codecNameText.setText(self.codecName)
             ratio = round(1.0)
-            if ratio!=self.compressRatio :
+            if ratio != self.compressRatio:
                 self.compressRatio = ratio
                 self.compressRatioText.setText(str(self.compressRatio))
             self.imageDict["dtype"] = data.dtype
             self.dtypeText.setText(str(self.imageDict["dtype"]))
         try:
-            if codecNameLength != 0 : 
-                data = self.decompress(data,codec,compressed,uncompressed)
-            self.dataToImage(data,dimArray)
+            if codecNameLength != 0:
+                data = self.decompress(data, codec, compressed, uncompressed)
+            self.dataToImage(data, dimArray)
             self.imageControl.newImage(self.imageDict)
             self.imageControl.display()
         except Exception as error:
@@ -682,143 +727,156 @@ class NTNDA_Viewer(QWidget) :
         self.nImages = self.nImages + 1
         self.timenow = time.time()
         timediff = self.timenow - self.lasttime
-        if(timediff>1) :
-            self.imageRateText.setText(str(round(self.nImages/timediff)))
-            self.lasttime = self.timenow 
+        if (timediff > 1):
+            self.imageRateText.setText(str(round(self.nImages / timediff)))
+            self.lasttime = self.timenow
             self.nImages = 0
 
-    def decompress(self,data,codec,compressed,uncompressed) :
+    def decompress(self, data, codec, compressed, uncompressed):
         codecName = codec['name']
-        if codecName!=self.codecName : 
+        if codecName != self.codecName:
             self.codecName = codecName
             self.codecNameText.setText(self.codecName)
         typevalue = codec['parameters']
-        if typevalue== 1 : dtype = "int8"; elementsize =int(1)
-        elif typevalue== 5 : dtype = "uint8"; elementsize =int(1)
-        elif typevalue== 2 : dtype = "int16"; elementsize =int(2)
-        elif typevalue== 6 : dtype = "uint16"; elementsize =int(2)
-        elif typevalue== 3 : dtype = "int32"; elementsize =int(4)
-        elif typevalue== 7 : dtype = "uint32"; elementsize =int(4)
-        elif typevalue== 4 : dtype = "int64"; elementsize =int(8)
-        elif typevalue== 8 : dtype = "uint64"; elementsize =int(8)
-        elif typevalue== 9 : dtype = "float32"; elementsize =int(4)
-        elif typevalue== 10 : dtype = "float64"; elementsize =int(8)
-        else : raise Exception('decompress mapIntToType failed')
-        if codecName=='blosc':
+        if typevalue == 1:
+            dtype = "int8"; elementsize = int(1)
+        elif typevalue == 5:
+            dtype = "uint8"; elementsize = int(1)
+        elif typevalue == 2:
+            dtype = "int16"; elementsize = int(2)
+        elif typevalue == 6:
+            dtype = "uint16"; elementsize = int(2)
+        elif typevalue == 3:
+            dtype = "int32"; elementsize = int(4)
+        elif typevalue == 7:
+            dtype = "uint32"; elementsize = int(4)
+        elif typevalue == 4:
+            dtype = "int64"; elementsize = int(8)
+        elif typevalue == 8:
+            dtype = "uint64"; elementsize = int(8)
+        elif typevalue == 9:
+            dtype = "float32"; elementsize = int(4)
+        elif typevalue == 10:
+            dtype = "float64"; elementsize = int(8)
+        else:
+            raise Exception('decompress mapIntToType failed')
+        if codecName == 'blosc':
             lib = self.findLibrary.find(codecName)
-        elif codecName=='jpeg' :
+        elif codecName == 'jpeg':
             lib = self.findLibrary.find('decompressJPEG')
-        elif codecName=='lz4' or codecName=='bslz4' :
+        elif codecName == 'lz4' or codecName == 'bslz4':
             lib = self.findLibrary.find('bitshuffle')
-        else : lib = None
-        if lib==None : raise Exception('shared library ' +codecName + ' not found')
+        else:
+            lib = None
+        if lib is None:
+            raise Exception(
+            'shared library ' + codecName + ' not found')
         self.imageDict["dtype"] = dtype
         self.dtypeText.setText(str(self.imageDict["dtype"]))
         inarray = bytearray(data)
         in_char_array = ctypes.c_ubyte * compressed
         out_char_array = ctypes.c_ubyte * uncompressed
         outarray = bytearray(uncompressed)
-        if codecName=='blosc' : 
+        if codecName == 'blosc':
             lib.blosc_decompress(
-                 in_char_array.from_buffer(inarray),
-                 out_char_array.from_buffer(outarray),uncompressed)
+                in_char_array.from_buffer(inarray),
+                out_char_array.from_buffer(outarray), uncompressed)
             data = np.array(outarray)
-            data = np.frombuffer(data,dtype=dtype)
-        elif codecName=='lz4' :
+            data = np.frombuffer(data, dtype=dtype)
+        elif codecName == 'lz4':
             lib.LZ4_decompress_fast(
-                 in_char_array.from_buffer(inarray),
-                 out_char_array.from_buffer(outarray),uncompressed)
+                in_char_array.from_buffer(inarray),
+                out_char_array.from_buffer(outarray), uncompressed)
             data = np.array(outarray)
-            data = np.frombuffer(data,dtype=dtype)
-        elif codecName=='bslz4' :
+            data = np.frombuffer(data, dtype=dtype)
+        elif codecName == 'bslz4':
             lib.bshuf_decompress_lz4(
-                 in_char_array.from_buffer(inarray),
-                 out_char_array.from_buffer(outarray),int(uncompressed/elementsize),
-                 elementsize,int(0))
+                in_char_array.from_buffer(inarray),
+                out_char_array.from_buffer(outarray),
+                int(uncompressed / elementsize),
+                elementsize, int(0))
             data = np.array(outarray)
-            data = np.frombuffer(data,dtype=dtype)
-        elif codecName=='jpeg' :
+            data = np.frombuffer(data, dtype=dtype)
+        elif codecName == 'jpeg':
             lib.decompressJPEG(
-                 in_char_array.from_buffer(inarray),compressed,
-                 out_char_array.from_buffer(outarray),uncompressed)
+                in_char_array.from_buffer(inarray), compressed,
+                out_char_array.from_buffer(outarray), uncompressed)
             data = np.array(outarray)
             data = data.flatten()
-        else : raise Exception(codecName + " is unsupported codec")
-        ratio = round(float(uncompressed/compressed))
-        if ratio!=self.compressRatio :
+        else:
+            raise Exception(codecName + " is unsupported codec")
+        ratio = round(float(uncompressed / compressed))
+        if ratio != self.compressRatio:
             self.compressRatio = ratio
             self.compressRatioText.setText(str(self.compressRatio))
         return data
 
-    def dataToImage(self,data,dimArray) :
+    def dataToImage(self, data, dimArray):
         ny = 0
         nx = 0
         nz = 1
         dtype = data.dtype
         ndim = len(dimArray)
-        if ndim!=2 and ndim!=3 :
+        if ndim != 2 and ndim != 3:
             raise Exception('ndim not 2 or 3')
-            return
-        if ndim ==2 :
+        if ndim == 2:
             nx = dimArray[0]["size"]
             ny = dimArray[1]["size"]
-            image = np.reshape(data,(ny,nx))
+            image = np.reshape(data, (ny, nx))
             image = np.transpose(image)
-        elif ndim ==3 :
-            if dimArray[0]["size"]==3 :
+        elif ndim == 3:
+            if dimArray[0]["size"] == 3:
                 nz = dimArray[0]["size"]
                 nx = dimArray[1]["size"]
                 ny = dimArray[2]["size"]
-                image = np.reshape(data,(ny,nx,nz))
-                image = np.transpose(image,(1,0,2))
-            elif dimArray[1]["size"]==3 :
+                image = np.reshape(data, (ny, nx, nz))
+                image = np.transpose(image, (1, 0, 2))
+            elif dimArray[1]["size"] == 3:
                 nz = dimArray[1]["size"]
                 nx = dimArray[0]["size"]
                 ny = dimArray[2]["size"]
-                image = np.reshape(data,(ny,nz,nx))
-                image = np.swapaxes(image,2,1)
-                image = np.transpose(image,(1,0,2))
-            elif dimArray[2]["size"]==3 :
+                image = np.reshape(data, (ny, nz, nx))
+                image = np.swapaxes(image, 2, 1)
+                image = np.transpose(image, (1, 0, 2))
+            elif dimArray[2]["size"] == 3:
                 nz = dimArray[2]["size"]
                 nx = dimArray[0]["size"]
                 ny = dimArray[1]["size"]
-                image = np.reshape(data,(nz,ny,nx))
-                image = np.swapaxes(image,0,2)
-                image = np.swapaxes(image,0,1)
-                image = np.transpose(image,(1,0,2))
-            else  :  
+                image = np.reshape(data, (nz, ny, nx))
+                image = np.swapaxes(image, 0, 2)
+                image = np.swapaxes(image, 0, 1)
+                image = np.transpose(image, (1, 0, 2))
+            else:
                 raise Exception('no axis has dim = 3')
-                return
-        else :
-                raise Exception('ndim not 2 or 3')
-        if dtype!=self.imageDict["dtype"] :
+        else:
+            raise Exception('ndim not 2 or 3')
+        if dtype != self.imageDict["dtype"]:
             self.imageDict["dtype"] = dtype
             self.dtypeText.setText(str(self.imageDict["dtype"]))
-        if ny <self.minsize or nx<self.minsize :
-            raise Exception('ny <',self.minsize,' or nx<',self.minsize)
-        if nx!=self.imageDict["nx"] :
+        if ny < self.minsize or nx < self.minsize:
+            raise Exception('ny <', self.minsize, ' or nx<', self.minsize)
+        if nx != self.imageDict["nx"]:
             self.imageDict["nx"] = nx
             self.nxText.setText(str(self.imageDict["nx"]))
-        if ny!=self.imageDict["ny"] :
+        if ny != self.imageDict["ny"]:
             self.imageDict["ny"] = ny
             self.nyText.setText(str(self.imageDict["ny"]))
-        if nz!=self.imageDict["nz"] :
+        if nz != self.imageDict["nz"]:
             self.imageDict["nz"] = nz
             self.nzText.setText(str(self.imageDict["nz"]))
         width = nx
         height = ny
-        if width==height :
-            if width>self.maxsize : width = self.maxsize
-            if height>self.maxsize : height = self.maxsize
-        elif width<height :
-            ratio = width/height
-            if height>self.maxsize : height = self.maxsize
-            width = height*ratio
-        else :
-            ratio = height/width
-            if width>self.maxsize : width = self.maxsize
-            height = width*ratio
+        if width == height:
+            if width > self.maxsize: width = self.maxsize
+            if height > self.maxsize: height = self.maxsize
+        elif width < height:
+            ratio = width / height
+            if height > self.maxsize: height = self.maxsize
+            width = height * ratio
+        else:
+            ratio = height / width
+            if width > self.maxsize: width = self.maxsize
+            height = width * ratio
         self.width = width
         self.height = height
         self.imageDict["image"] = image
-

--- a/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -710,7 +710,7 @@ class NTNDA_Viewer(QWidget):
             if codecName != self.codecName:
                 self.codecName = codecName
                 self.codecNameText.setText(self.codecName)
-            ratio = round(1.0)
+            ratio = 1
             if ratio != self.compressRatio:
                 self.compressRatio = ratio
                 self.compressRatioText.setText(str(self.compressRatio))
@@ -727,7 +727,7 @@ class NTNDA_Viewer(QWidget):
         self.nImages = self.nImages + 1
         self.timenow = time.time()
         timediff = self.timenow - self.lasttime
-        if (timediff > 1):
+        if timediff > 1:
             self.imageRateText.setText(str(round(self.nImages / timediff)))
             self.lasttime = self.timenow
             self.nImages = 0

--- a/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -42,12 +42,12 @@ class NTNDA_Channel_Provider(object):
     def start(self):
         """Called to start monitoring."""
         raise Exception(
-            'derived class must implement NTNDA_Channel_Provider.start')
+            "derived class must implement NTNDA_Channel_Provider.start")
 
     def stop(self):
         """Called to stop monitoring."""
         raise Exception(
-            'derived class must implement NTNDA_Channel_Provider.stop')
+            "derived class must implement NTNDA_Channel_Provider.stop")
 
     def done(self):
         """Called when NTNDA_Viewer is done."""
@@ -56,7 +56,7 @@ class NTNDA_Channel_Provider(object):
     def callback(self, arg):
         """Must call NTNDA_Viewer.callback(arg)."""
         raise Exception(
-            'derived class must implement NTNDA_Channel_Provider.callback')
+            "derived class must implement NTNDA_Channel_Provider.callback")
 
 
 def imageDictCreate():
@@ -141,7 +141,7 @@ class ImageControl(QWidget):
         highLabel.setFixedWidth(100)
         maximumLabel = QLabel("maximum")
         maximumLabel.setFixedWidth(80)
-        zoomLabel = QLabel('||    zoom        (xlow,ylow,numx.numy)')
+        zoomLabel = QLabel("||    zoom        (xlow,ylow,numx.numy)")
         box = QHBoxLayout()
         box.setContentsMargins(0, 0, 0, 0);
         box.addWidget(minimumLabel)
@@ -155,25 +155,24 @@ class ImageControl(QWidget):
         self.firstRow = wid
         # second row
         self.minimumText = QLineEdit()
-        self.minimumText.setText('')
+        self.minimumText.setText("")
         self.minimumText.setEnabled(True)
         self.minimumText.setFixedWidth(100)
         self.minimumText.editingFinished.connect(self.minimumEvent)
-        self.lowText = QLabel('')
+        self.lowText = QLabel("")
         self.lowText.setFixedWidth(100)
-        spaceLabel = QLabel('')
+        spaceLabel = QLabel("")
         spaceLabel.setFixedWidth(100)
-        self.highText = QLabel('')
+        self.highText = QLabel("")
         self.highText.setFixedWidth(100)
         self.maximumText = QLineEdit()
         self.maximumText.setFixedWidth(80)
         self.maximumText.editingFinished.connect(self.maximumEvent)
         self.maximumText.setEnabled(True)
-        self.maximumText.setText('')
-        dividerLabel = QLabel('||')
+        self.maximumText.setText("")
+        dividerLabel = QLabel("||")
         dividerLabel.setFixedWidth(20)
-        self.resetButton = QPushButton('reset')
-        self.resetButton.setFixedWidth(40)
+        self.resetButton = QPushButton("reset")
         self.resetButton.setEnabled(True)
         self.resetButton.clicked.connect(self.resetEvent)
         self.zoomText = QLineEdit()
@@ -236,7 +235,7 @@ class ImageControl(QWidget):
         self.ylow = 0
         self.numx = self.imageDict["nx"]
         self.numy = self.imageDict["ny"]
-        zoom = '(0,0,' + str(self.numx) + ',' + str(self.numy) + ')'
+        zoom = "(0,0," + str(self.numx) + "," + str(self.numy) + ")"
         self.zoomText.setText(zoom)
         self.isZoomImage = False
         self.imageDisplay.display(self.imageDict["image"], self.pixelLevels)
@@ -251,7 +250,7 @@ class ImageControl(QWidget):
         ymax = releasePosition.y()
         if xmin == xmax and ymin >= ymax: return
         if xmin >= xmax or ymin >= ymax:
-            self.statusText.setText('illegal mouse move')
+            self.statusText.setText("illegal mouse move")
             return
         if self.isZoomImage:
             xstart = self.xlow
@@ -278,46 +277,46 @@ class ImageControl(QWidget):
         ylow = int(ymin * ratioy) + self.ylow
         numx = int((xmax - xmin) * ratiox)
         numy = int((ymax - ymin) * ratioy)
-        zoom = '(' + str(xlow) + ',' + str(ylow) + ',' + str(numx) + ',' + str(
-            numy) + ')'
+        zoom = "(" + str(xlow) + "," + str(ylow) + "," + str(numx) + "," + str(
+            numy) + ")"
         self.zoomText.setText(zoom)
         self.zoomTextEvent()
 
     def zoomTextEvent(self):
         try:
             text = self.zoomText.text()
-            ind = text.find('(')
-            if ind < 0: raise Exception('does not start with (')
+            ind = text.find("(")
+            if ind < 0: raise Exception("does not start with (")
             text = text[(ind + 1):]
-            ind = text.find(')')
-            if ind < 0: raise Exception('does not end with )')
+            ind = text.find(")")
+            if ind < 0: raise Exception("does not end with )")
             text = text[:-1]
-            split = text.split(',')
-            if len(split) != 4: raise Exception('not four values')
+            split = text.split(",")
+            if len(split) != 4: raise Exception("not four values")
             xlow = split[0]
             if not xlow.isdigit(): raise Exception(
-                'xlow is not a positive integer')
+                "xlow is not a positive integer")
             xlow = int(xlow)
             ylow = split[1]
             if not ylow.isdigit(): raise Exception(
-                'ylow is not a positive integer')
+                "ylow is not a positive integer")
             ylow = int(ylow)
             numx = split[2]
             if not numx.isdigit(): raise Exception(
-                'numx is not a positive integer')
+                "numx is not a positive integer")
             numx = int(numx)
-            if numx < 1: raise Exception('numx must be at least 1')
+            if numx < 1: raise Exception("numx must be at least 1")
             numy = split[3]
             if not numy.isdigit(): raise Exception(
-                'numy is not a positive integer')
+                "numy is not a positive integer")
             numy = int(numy)
-            if numy < 1: raise Exception('numy must be at least 1')
+            if numy < 1: raise Exception("numy must be at least 1")
             sizex = xlow + numx
             if sizex > self.imageDict["nx"]: raise Exception(
-                'xlow + numx gt nx')
+                "xlow + numx gt nx")
             sizey = ylow + numy
             if sizey > self.imageDict["ny"]: raise Exception(
-                'ylow + numy gt ny')
+                "ylow + numy gt ny")
         except Exception as error:
             self.statusText.setText(str(error))
             self.statusText.setStyleSheet("background-color:red")
@@ -347,7 +346,7 @@ class ImageControl(QWidget):
                         image[indx][indy][indz] = \
                         fromimage[indx + self.xlow][indy + self.ylow][indz]
         else:
-            raise Exception('ndim not 2 or 3')
+            raise Exception("ndim not 2 or 3")
         self.imageDisplay.display(image, self.pixelLevels)
         self.imageDisplay.show()
 
@@ -454,7 +453,7 @@ class ImageControl(QWidget):
             elif dtype == str("float64"):
                 self.pixelLevels = (float(0.0), float(1.0))
             else:
-                raise Exception('unknown dtype' + dtype)
+                raise Exception("unknown dtype" + dtype)
                 return
             self.minimum = self.pixelLevels[0]
             self.minimumText.setText(str(self.minimum))
@@ -466,8 +465,8 @@ class ImageControl(QWidget):
             self.highText.setText(str(self.high))
             self.lowSlider.setValue(0)
             self.highSlider.setValue(self.npixelLevels)
-            zoom = '(0,0,' + str(self.imageDict["nx"]) + ',' + str(
-                self.imageDict["ny"]) + ')'
+            zoom = "(0,0," + str(self.imageDict["nx"]) + "," + str(
+                self.imageDict["ny"]) + ")"
             self.zoomText.setText(zoom)
             self.isZoomImage = False
 
@@ -491,7 +490,7 @@ class FindLibrary(object):
         result = ctypes.util.find_library(name)
         if not result:
             return None
-        if os.name == 'nt':
+        if os.name == "nt":
             lib = ctypes.windll.LoadLibrary(result)
         else:
             lib = ctypes.cdll.LoadLibrary(result)
@@ -509,17 +508,17 @@ class NTNDA_Viewer(QWidget):
         self.setWindowTitle(providerName + "_NTNDA_Viewer")
         self.imageDict = imageDictCreate()
         # first row
-        self.startButton = QPushButton('start')
+        self.startButton = QPushButton("start")
         self.startButton.setEnabled(True)
         self.startButton.clicked.connect(self.startEvent)
-        self.startButton.setFixedWidth(40)
+        self.startButton.resize(self.startButton.sizeHint())
         self.isStarted = False
-        self.stopButton = QPushButton('stop')
+        self.stopButton = QPushButton("stop")
         self.stopButton.setEnabled(False)
         self.stopButton.clicked.connect(self.stopEvent)
-        self.stopButton.setFixedWidth(40)
+        self.stopButton.resize(self.stopButton.sizeHint())
         if len(self.provider.getChannelName()) < 1:
-            name = os.getenv('EPICS_NTNDA_VIEWER_CHANNELNAME')
+            name = os.getenv("EPICS_NTNDA_VIEWER_CHANNELNAME")
             if name:
                 self.provider.setChannelName(name)
         self.nImages = 0
@@ -552,7 +551,7 @@ class NTNDA_Viewer(QWidget):
         self.dtype = None
         self.dtypeText = QLabel()
         self.dtypeText.setFixedWidth(50)
-        self.codecName = ''
+        self.codecName = ""
         self.codecNameText = QLabel()
         self.codecNameText.setFixedWidth(40)
 
@@ -560,28 +559,28 @@ class NTNDA_Viewer(QWidget):
         self.compressRatioText.setFixedWidth(40)
         self.compressRatio = round(1.0)
         self.compressRatioText.setText(str(self.compressRatio))
-        self.clearButton = QPushButton('clear')
+        self.clearButton = QPushButton("clear")
         self.clearButton.setEnabled(True)
         self.clearButton.clicked.connect(self.clearEvent)
-        self.clearButton.setFixedWidth(40)
+        self.clearButton.resize(self.clearButton.sizeHint())
         self.statusText = QLineEdit()
-        self.statusText.setText('nothing done so far')
+        self.statusText.setText("nothing done so far")
         self.statusText.setFixedWidth(200)
         box = QHBoxLayout()
         box.setContentsMargins(0, 0, 0, 0);
         nxLabel = QLabel("nx:")
         nxLabel.setFixedWidth(20)
-        self.nxText.setText('0')
+        self.nxText.setText("0")
         box.addWidget(nxLabel)
         box.addWidget(self.nxText)
         nyLabel = QLabel("ny:")
         nyLabel.setFixedWidth(20)
-        self.nyText.setText('0')
+        self.nyText.setText("0")
         box.addWidget(nyLabel)
         box.addWidget(self.nyText)
         nzLabel = QLabel("nz:")
         nzLabel.setFixedWidth(20)
-        self.nzText.setText('0')
+        self.nzText.setText("0")
         box.addWidget(nzLabel)
         box.addWidget(self.nzText)
         dtypeLabel = QLabel("dtype:")
@@ -643,7 +642,7 @@ class NTNDA_Viewer(QWidget):
         self.stop()
 
     def clearEvent(self):
-        self.statusText.setText('')
+        self.statusText.setText("")
         self.statusText.setStyleSheet("background-color:white")
 
     def channelNameEvent(self):
@@ -680,33 +679,33 @@ class NTNDA_Viewer(QWidget):
             if value is not None:
                 if value == "disconnected":
                     self.channelNameLabel.setStyleSheet("background-color:red")
-                    self.statusText.setText('disconnected')
+                    self.statusText.setText("disconnected")
                     return
                 elif value == "connected":
                     self.channelNameLabel.setStyleSheet(
                         "background-color:green")
-                    self.statusText.setText('connected')
+                    self.statusText.setText("connected")
                     return
                 else:
                     self.statusText.setText("unknown callback error")
                     return
         try:
-            data = arg['value']
-            dimArray = arg['dimension']
-            compressed = arg['compressedSize']
-            uncompressed = arg['uncompressedSize']
-            codec = arg['codec']
-            codecName = codec['name']
+            data = arg["value"]
+            dimArray = arg["dimension"]
+            compressed = arg["compressedSize"]
+            uncompressed = arg["uncompressedSize"]
+            codec = arg["codec"]
+            codecName = codec["name"]
             codecNameLength = len(codecName)
         except Exception as error:
             self.statusText.setText(str(error))
             return
         ndim = len(dimArray)
         if ndim != 2 and ndim != 3:
-            self.statusText.setText('ndim not 2 or 3')
+            self.statusText.setText("ndim not 2 or 3")
             return
         if codecNameLength == 0:
-            codecName = 'none'
+            codecName = "none"
             if codecName != self.codecName:
                 self.codecName = codecName
                 self.codecNameText.setText(self.codecName)
@@ -733,11 +732,11 @@ class NTNDA_Viewer(QWidget):
             self.nImages = 0
 
     def decompress(self, data, codec, compressed, uncompressed):
-        codecName = codec['name']
+        codecName = codec["name"]
         if codecName != self.codecName:
             self.codecName = codecName
             self.codecNameText.setText(self.codecName)
-        typevalue = codec['parameters']
+        typevalue = codec["parameters"]
         if typevalue == 1:
             dtype = "int8"; elementsize = int(1)
         elif typevalue == 5:
@@ -759,37 +758,37 @@ class NTNDA_Viewer(QWidget):
         elif typevalue == 10:
             dtype = "float64"; elementsize = int(8)
         else:
-            raise Exception('decompress mapIntToType failed')
-        if codecName == 'blosc':
+            raise Exception("decompress mapIntToType failed")
+        if codecName == "blosc":
             lib = self.findLibrary.find(codecName)
-        elif codecName == 'jpeg':
-            lib = self.findLibrary.find('decompressJPEG')
-        elif codecName == 'lz4' or codecName == 'bslz4':
-            lib = self.findLibrary.find('bitshuffle')
+        elif codecName == "jpeg":
+            lib = self.findLibrary.find("decompressJPEG")
+        elif codecName == "lz4" or codecName == "bslz4":
+            lib = self.findLibrary.find("bitshuffle")
         else:
             lib = None
         if lib is None:
             raise Exception(
-            'shared library ' + codecName + ' not found')
+            "shared library " + codecName + " not found")
         self.imageDict["dtype"] = dtype
         self.dtypeText.setText(str(self.imageDict["dtype"]))
         inarray = bytearray(data)
         in_char_array = ctypes.c_ubyte * compressed
         out_char_array = ctypes.c_ubyte * uncompressed
         outarray = bytearray(uncompressed)
-        if codecName == 'blosc':
+        if codecName == "blosc":
             lib.blosc_decompress(
                 in_char_array.from_buffer(inarray),
                 out_char_array.from_buffer(outarray), uncompressed)
             data = np.array(outarray)
             data = np.frombuffer(data, dtype=dtype)
-        elif codecName == 'lz4':
+        elif codecName == "lz4":
             lib.LZ4_decompress_fast(
                 in_char_array.from_buffer(inarray),
                 out_char_array.from_buffer(outarray), uncompressed)
             data = np.array(outarray)
             data = np.frombuffer(data, dtype=dtype)
-        elif codecName == 'bslz4':
+        elif codecName == "bslz4":
             lib.bshuf_decompress_lz4(
                 in_char_array.from_buffer(inarray),
                 out_char_array.from_buffer(outarray),
@@ -797,7 +796,7 @@ class NTNDA_Viewer(QWidget):
                 elementsize, int(0))
             data = np.array(outarray)
             data = np.frombuffer(data, dtype=dtype)
-        elif codecName == 'jpeg':
+        elif codecName == "jpeg":
             lib.decompressJPEG(
                 in_char_array.from_buffer(inarray), compressed,
                 out_char_array.from_buffer(outarray), uncompressed)
@@ -818,7 +817,7 @@ class NTNDA_Viewer(QWidget):
         dtype = data.dtype
         ndim = len(dimArray)
         if ndim != 2 and ndim != 3:
-            raise Exception('ndim not 2 or 3')
+            raise Exception("ndim not 2 or 3")
         if ndim == 2:
             nx = dimArray[0]["size"]
             ny = dimArray[1]["size"]
@@ -847,14 +846,14 @@ class NTNDA_Viewer(QWidget):
                 image = np.swapaxes(image, 0, 1)
                 image = np.transpose(image, (1, 0, 2))
             else:
-                raise Exception('no axis has dim = 3')
+                raise Exception("no axis has dim = 3")
         else:
-            raise Exception('ndim not 2 or 3')
+            raise Exception("ndim not 2 or 3")
         if dtype != self.imageDict["dtype"]:
             self.imageDict["dtype"] = dtype
             self.dtypeText.setText(str(self.imageDict["dtype"]))
         if ny < self.minsize or nx < self.minsize:
-            raise Exception('ny <', self.minsize, ' or nx<', self.minsize)
+            raise Exception("ny <", self.minsize, " or nx<", self.minsize)
         if nx != self.imageDict["nx"]:
             self.imageDict["nx"] = nx
             self.nxText.setText(str(self.imageDict["nx"]))

--- a/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/NTNDA_Viewer.py
@@ -120,7 +120,7 @@ class ImageControl(QWidget):
         self.imageDict = imageDictCreate()
         self.pixelLevels = (0, 255)
         self.npixelLevels = 255
-        self.minimum = 0;
+        self.minimum = 0
         self.low = 0
         self.high = self.npixelLevels
         self.maximum = self.npixelLevels
@@ -143,11 +143,11 @@ class ImageControl(QWidget):
         maximumLabel.setFixedWidth(80)
         zoomLabel = QLabel("||    zoom        (xlow,ylow,numx.numy)")
         box = QHBoxLayout()
-        box.setContentsMargins(0, 0, 0, 0);
+        box.setContentsMargins(0, 0, 0, 0)
         box.addWidget(minimumLabel)
-        box.addWidget(lowLabel);
-        box.addWidget(titleLabel);
-        box.addWidget(highLabel);
+        box.addWidget(lowLabel)
+        box.addWidget(titleLabel)
+        box.addWidget(highLabel)
         box.addWidget(maximumLabel)
         box.addWidget(zoomLabel)
         wid = QWidget()
@@ -181,7 +181,7 @@ class ImageControl(QWidget):
         self.zoomText.setFixedWidth(180)
         self.zoomText.editingFinished.connect(self.zoomTextEvent)
         box = QHBoxLayout()
-        box.setContentsMargins(0, 0, 0, 0);
+        box.setContentsMargins(0, 0, 0, 0)
         box.addWidget(self.minimumText)
         box.addWidget(self.lowText)
         box.addWidget(spaceLabel)
@@ -195,7 +195,7 @@ class ImageControl(QWidget):
         self.secondRow = wid
         # third row
         self.lowSlider = QSlider(Qt.Horizontal)
-        self.lowSlider.setContentsMargins(0, 0, 0, 0);
+        self.lowSlider.setContentsMargins(0, 0, 0, 0)
         self.lowSlider.setMinimum(0)
         self.lowSlider.setMaximum(self.npixelLevels)
         self.lowSlider.setValue(0)
@@ -203,7 +203,7 @@ class ImageControl(QWidget):
         self.lowSlider.setTickInterval(10)
         self.lowSlider.setFixedWidth(256)
         self.highSlider = QSlider(Qt.Horizontal)
-        self.highSlider.setContentsMargins(0, 0, 0, 0);
+        self.highSlider.setContentsMargins(0, 0, 0, 0)
         self.highSlider.setMinimum(0)
         self.highSlider.setMaximum(self.npixelLevels)
         self.highSlider.setValue(self.npixelLevels)
@@ -212,8 +212,8 @@ class ImageControl(QWidget):
         self.highSlider.setFixedWidth(256)
         box = QHBoxLayout()
         box.addStretch(0)
-        box.setSpacing(0);
-        box.setContentsMargins(0, 0, 0, 0);
+        box.setSpacing(0)
+        box.setContentsMargins(0, 0, 0, 0)
         box.setGeometry(QRect(0, 0, 500, 20))
         box.addWidget(self.lowSlider)
         box.addWidget(self.highSlider)
@@ -222,7 +222,7 @@ class ImageControl(QWidget):
         self.thirdRow = wid
         # create window
         layout = QGridLayout()
-        layout.setSpacing(0);
+        layout.setSpacing(0)
         layout.addWidget(self.firstRow, 0, 0, alignment=Qt.AlignLeft)
         layout.addWidget(self.secondRow, 1, 0, alignment=Qt.AlignLeft)
         layout.addWidget(self.thirdRow, 2, 0, alignment=Qt.AlignLeft)
@@ -287,37 +287,42 @@ class ImageControl(QWidget):
         try:
             text = self.zoomText.text()
             ind = text.find("(")
-            if ind < 0: raise Exception("does not start with (")
+            if ind < 0:
+                raise Exception("does not start with (")
             text = text[(ind + 1):]
             ind = text.find(")")
-            if ind < 0: raise Exception("does not end with )")
+            if ind < 0:
+                raise Exception("does not end with )")
             text = text[:-1]
             split = text.split(",")
-            if len(split) != 4: raise Exception("not four values")
+            if len(split) != 4:
+                raise Exception("not four values")
             xlow = split[0]
-            if not xlow.isdigit(): raise Exception(
-                "xlow is not a positive integer")
+            if not xlow.isdigit():
+                raise Exception("xlow is not a positive integer")
             xlow = int(xlow)
             ylow = split[1]
-            if not ylow.isdigit(): raise Exception(
-                "ylow is not a positive integer")
+            if not ylow.isdigit():
+                raise Exception("ylow is not a positive integer")
             ylow = int(ylow)
             numx = split[2]
-            if not numx.isdigit(): raise Exception(
-                "numx is not a positive integer")
+            if not numx.isdigit():
+                raise Exception("numx is not a positive integer")
             numx = int(numx)
-            if numx < 1: raise Exception("numx must be at least 1")
+            if numx < 1:
+                raise Exception("numx must be at least 1")
             numy = split[3]
-            if not numy.isdigit(): raise Exception(
-                "numy is not a positive integer")
+            if not numy.isdigit():
+                raise Exception("numy is not a positive integer")
             numy = int(numy)
-            if numy < 1: raise Exception("numy must be at least 1")
+            if numy < 1:
+                raise Exception("numy must be at least 1")
             sizex = xlow + numx
-            if sizex > self.imageDict["nx"]: raise Exception(
-                "xlow + numx gt nx")
+            if sizex > self.imageDict["nx"]:
+                raise Exception("xlow + numx gt nx")
             sizey = ylow + numy
-            if sizey > self.imageDict["ny"]: raise Exception(
-                "ylow + numy gt ny")
+            if sizey > self.imageDict["ny"]:
+                raise Exception("ylow + numy gt ny")
         except Exception as error:
             self.statusText.setText(str(error))
             self.statusText.setStyleSheet("background-color:red")
@@ -393,7 +398,8 @@ class ImageControl(QWidget):
         pixelRatio = float(self.lowSlider.value()) / float(self.npixelLevels)
         valueRange = float(self.maximum) - float(self.minimum)
         value = pixelRatio * valueRange + self.minimum
-        if value > self.maximum: value = self.maximum
+        if value > self.maximum:
+            value = self.maximum
         if value > self.high:
             self.high = value
             self.highText.setText(str(round(self.high)))
@@ -454,7 +460,6 @@ class ImageControl(QWidget):
                 self.pixelLevels = (0.0, 1.0)
             else:
                 raise Exception("unknown dtype" + dtype)
-                return
             self.minimum = self.pixelLevels[0]
             self.minimumText.setText(str(self.minimum))
             self.low = self.minimum
@@ -526,7 +531,7 @@ class NTNDA_Viewer(QWidget):
         self.channelNameText.setText(self.provider.getChannelName())
         self.channelNameText.editingFinished.connect(self.channelNameEvent)
         box = QHBoxLayout()
-        box.setContentsMargins(0, 0, 0, 0);
+        box.setContentsMargins(0, 0, 0, 0)
         box.addWidget(self.startButton)
         box.addWidget(self.stopButton)
         imageRateLabel = QLabel("imageRate:")
@@ -563,7 +568,7 @@ class NTNDA_Viewer(QWidget):
         self.statusText.setText("nothing done so far")
         self.statusText.setFixedWidth(200)
         box = QHBoxLayout()
-        box.setContentsMargins(0, 0, 0, 0);
+        box.setContentsMargins(0, 0, 0, 0)
         nxLabel = QLabel("nx:")
         nxLabel.setFixedWidth(20)
         self.nxText.setText("0")
@@ -600,14 +605,14 @@ class NTNDA_Viewer(QWidget):
         # third row
         self.imageControl = ImageControl(self.statusText)
         box = QHBoxLayout()
-        box.setContentsMargins(0, 0, 0, 0);
+        box.setContentsMargins(0, 0, 0, 0)
         box.addWidget(self.imageControl)
         wid = QWidget()
         wid.setLayout(box)
         self.thirdRow = wid
         # initialize
         layout = QGridLayout()
-        layout.setVerticalSpacing(0);
+        layout.setVerticalSpacing(0)
         layout.addWidget(self.firstRow, 0, 0)
         layout.addWidget(self.secondRow, 1, 0)
         layout.addWidget(self.thirdRow, 2, 0)
@@ -816,9 +821,6 @@ class NTNDA_Viewer(QWidget):
         return data
 
     def dataToImage(self, data, dimArray):
-        ny = 0
-        nx = 0
-        nz = 1
         dtype = data.dtype
         ndim = len(dimArray)
         if ndim != 2 and ndim != 3:
@@ -826,6 +828,7 @@ class NTNDA_Viewer(QWidget):
         if ndim == 2:
             nx = dimArray[0]["size"]
             ny = dimArray[1]["size"]
+            nz = 0
             image = np.reshape(data, (ny, nx))
             image = np.transpose(image)
         elif ndim == 3:

--- a/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
@@ -30,13 +30,13 @@ class P4PProvider(QObject, NTNDA_Channel_Provider):
         self.subscription = None
 
     def start(self):
-        self.ctxt = Context('pva')
+        self.ctxt = Context("pva")
         self.firstCallback = True
         self.isClosed = False
         self.subscription = self.ctxt.monitor(
             self.getChannelName(),
             self.p4pcallback,
-            request = 'field(value,dimension,codec,compressedSize,uncompressedSize)',
+            request = "field(value,dimension,codec,compressedSize,uncompressedSize)",
             notify_disconnect=True)
 
     def stop(self):
@@ -62,24 +62,24 @@ class P4PProvider(QObject, NTNDA_Channel_Provider):
         arg = {}
         try:
             argtype = str(type(struct))
-            if argtype.find('Disconnected') >= 0:
+            if argtype.find("Disconnected") >= 0:
                 arg["status"] = "disconnected"
                 self.callback(arg)
                 self.firstCallback = True
                 self.callbackDoneEvent.set()
                 return
             if self.firstCallback:
-                arg = dict()
-                arg["status"] = "connected"
+                arg = {"status": "connected"}
                 self.callback(arg)
                 self.firstCallback = False
                 self.callback(arg)
-            arg = dict()
-            arg['value'] = struct['value']
-            arg['dimension'] = struct['dimension']
-            arg['codec'] = struct['codec']
-            arg['compressedSize'] = struct['compressedSize']
-            arg['uncompressedSize'] = struct['uncompressedSize']
+            arg = {
+                "value": struct["value"],
+                "dimension": struct["dimension"],
+                "codec": struct["codec"],
+                "compressedSize":struct["compressedSize"],
+                "uncompressedSize": struct["uncompressedSize"],
+            }
             self.callback(arg)
             self.callbackDoneEvent.set()
             return
@@ -90,7 +90,7 @@ class P4PProvider(QObject, NTNDA_Channel_Provider):
             return
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = QApplication(sys.argv)
     p4pProvider = P4PProvider()
     channelName = ""

--- a/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
@@ -28,6 +28,7 @@ class P4PProvider(QObject, NTNDA_Channel_Provider):
         self.firstCallback = True
         self.isClosed = True
         self.subscription = None
+        self.struct = None
 
     def start(self):
         self.ctxt = Context("pva")
@@ -77,7 +78,7 @@ class P4PProvider(QObject, NTNDA_Channel_Provider):
                 "value": struct["value"],
                 "dimension": struct["dimension"],
                 "codec": struct["codec"],
-                "compressedSize":struct["compressedSize"],
+                "compressedSize": struct["compressedSize"],
                 "uncompressedSize": struct["uncompressedSize"],
             }
             self.callback(arg)

--- a/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
@@ -82,12 +82,10 @@ class P4PProvider(QObject, NTNDA_Channel_Provider):
             }
             self.callback(arg)
             self.callbackDoneEvent.set()
-            return
         except Exception as error:
             arg["exception"] = repr(error)
             self.callback(arg)
             self.callbackDoneEvent.set()
-            return
 
 
 if __name__ == "__main__":

--- a/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/P4P_NTNDA_Viewer.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-'''
+"""
 Copyright - See the COPYRIGHT that is included with this distribution.
     NTNDA_Viewer is distributed subject to a Software License Agreement found
     in file LICENSE that is included with this distribution.
@@ -7,17 +7,19 @@ Copyright - See the COPYRIGHT that is included with this distribution.
 author Marty Kraimer
     latest date 2020.03.02
     original development started 2019.12
-'''
+"""
 
-from NTNDA_Viewer import NTNDA_Viewer,NTNDA_Channel_Provider
+from NTNDA_Viewer import NTNDA_Viewer, NTNDA_Channel_Provider
 from p4p.client.thread import Context
 import sys
 from threading import Event
 from PyQt5.QtWidgets import QApplication
-from PyQt5.QtCore import QObject,pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSignal
 
-class P4PProvider(QObject,NTNDA_Channel_Provider) :
+
+class P4PProvider(QObject, NTNDA_Channel_Provider):
     callbacksignal = pyqtSignal()
+
     def __init__(self):
         QObject.__init__(self)
         NTNDA_Channel_Provider.__init__(self)
@@ -25,41 +27,48 @@ class P4PProvider(QObject,NTNDA_Channel_Provider) :
         self.callbackDoneEvent = Event()
         self.firstCallback = True
         self.isClosed = True
-        
-    def start(self) :
+        self.subscription = None
+
+    def start(self):
         self.ctxt = Context('pva')
         self.firstCallback = True
         self.isClosed = False
         self.subscription = self.ctxt.monitor(
-              self.getChannelName(),
-              self.p4pcallback,
-              request='field(value,dimension,codec,compressedSize,uncompressedSize)',
-              notify_disconnect=True)
-    def stop(self) :
+            self.getChannelName(),
+            self.p4pcallback,
+            request = 'field(value,dimension,codec,compressedSize,uncompressedSize)',
+            notify_disconnect=True)
+
+    def stop(self):
         self.isClosed = True
         self.ctxt.close()
-    def done(self) :
+
+    def done(self):
         pass
-    def callback(self,arg) :
+
+    def callback(self, arg):
         self.NTNDA_Viewer.callback(arg)
-    def p4pcallback(self,arg) :
-        if self.isClosed : return
-        self.struct = arg;
+
+    def p4pcallback(self, arg):
+        if self.isClosed:
+            return
+        self.struct = arg
         self.callbacksignal.emit()
         self.callbackDoneEvent.wait()
         self.callbackDoneEvent.clear()
-    def mycallback(self) :
+
+    def mycallback(self):
         struct = self.struct
-        arg = dict()
-        try :
+        arg = {}
+        try:
             argtype = str(type(struct))
-            if argtype.find('Disconnected')>=0 :
+            if argtype.find('Disconnected') >= 0:
                 arg["status"] = "disconnected"
                 self.callback(arg)
                 self.firstCallback = True
                 self.callbackDoneEvent.set()
                 return
-            if self.firstCallback :
+            if self.firstCallback:
                 arg = dict()
                 arg["status"] = "connected"
                 self.callback(arg)
@@ -80,14 +89,14 @@ class P4PProvider(QObject,NTNDA_Channel_Provider) :
             self.callbackDoneEvent.set()
             return
 
+
 if __name__ == '__main__':
     app = QApplication(sys.argv)
     p4pProvider = P4PProvider()
     channelName = ""
     nargs = len(sys.argv)
-    if nargs>=2 :
+    if nargs >= 2:
         channelName = sys.argv[1]
     p4pProvider.setChannelName(channelName)
-    viewer = NTNDA_Viewer(p4pProvider,"P4P")
+    viewer = NTNDA_Viewer(p4pProvider, "P4P")
     sys.exit(app.exec_())
-

--- a/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
@@ -19,11 +19,11 @@ from PyQt5.QtCore import QObject, pyqtSignal
 
 class GetChannel(object):
     """
-       This exists because whenever a new channel was started a crash occurred
+    This exists because whenever a new channel was started a crash occurred.
     """
 
     def __init__(self, parent=None):
-        self.save = dict()
+        self.save = {}
 
     def get(self, channelName):
         channel = self.save.get(channelName)
@@ -66,7 +66,7 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
 
     def mycallback(self):
         struct = self.struct
-        arg = dict()
+        arg = {}
         try:
             val = struct["value"][0]
             if len(val) != 1:
@@ -75,7 +75,7 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
             for x in val:
                 element = x
             if element is None:
-                raise Exception("value is not numpy  array")
+                raise Exception("value is not numpy array")
             value = val[element]
             arg["value"] = value
             arg["dimension"] = struct["dimension"]
@@ -86,20 +86,19 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
             else:
                 parameters = codec["parameters"]
                 typevalue = parameters[0]["value"]
-                cod = dict()
-                cod["name"] = codecName
-                cod["parameters"] = typevalue
-                arg["codec"] = cod
+                cod = {
+                    "name": codecName,
+                    "parameters": typevalue,
+                    "codec": codec,
+                }
             arg["compressedSize"] = struct["compressedSize"]
             arg["uncompressedSize"] = struct["uncompressedSize"]
             self.callback(arg)
             self.callbackDoneEvent.set()
-            return
         except Exception as error:
             arg["exception"] = repr(error)
             self.callback(arg)
             self.callbackDoneEvent.set()
-            return
 
 
 if __name__ == "__main__":

--- a/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
@@ -17,7 +17,7 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QObject, pyqtSignal
 
 
-class GetChannel(object):
+class GetChannel:
     """
     This exists because whenever a new channel was started a crash occurred.
     """

--- a/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
@@ -56,7 +56,7 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
         pass
 
     def pvapycallback(self, arg):
-        self.struct = arg;
+        self.struct = arg
         self.callbacksignal.emit()
         self.callbackDoneEvent.wait()
         self.callbackDoneEvent.clear()

--- a/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
+++ b/Python/PY_NTNDA_Viewer/PVAPY_NTNDA_Viewer.py
@@ -47,7 +47,7 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
     def start(self):
         self.channel = self.getChannel.get(self.getChannelName())
         self.channel.monitor(self.pvapycallback,
-                             'field(value,dimension,codec,compressedSize,uncompressedSize)')
+                             "field(value,dimension,codec,compressedSize,uncompressedSize)")
 
     def stop(self):
         self.channel.stopMonitor()
@@ -68,30 +68,30 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
         struct = self.struct
         arg = dict()
         try:
-            val = struct['value'][0]
+            val = struct["value"][0]
             if len(val) != 1:
-                raise Exception('value length not 1')
+                raise Exception("value length not 1")
             element = None
             for x in val:
                 element = x
             if element is None:
-                raise Exception('value is not numpy  array')
+                raise Exception("value is not numpy  array")
             value = val[element]
-            arg['value'] = value
-            arg['dimension'] = struct['dimension']
-            codec = struct['codec']
-            codecName = codec['name']
+            arg["value"] = value
+            arg["dimension"] = struct["dimension"]
+            codec = struct["codec"]
+            codecName = codec["name"]
             if len(codecName) < 1:
-                arg['codec'] = struct['codec']
+                arg["codec"] = struct["codec"]
             else:
-                parameters = codec['parameters']
-                typevalue = parameters[0]['value']
+                parameters = codec["parameters"]
+                typevalue = parameters[0]["value"]
                 cod = dict()
-                cod['name'] = codecName
-                cod['parameters'] = typevalue
-                arg['codec'] = cod
-            arg['compressedSize'] = struct['compressedSize']
-            arg['uncompressedSize'] = struct['uncompressedSize']
+                cod["name"] = codecName
+                cod["parameters"] = typevalue
+                arg["codec"] = cod
+            arg["compressedSize"] = struct["compressedSize"]
+            arg["uncompressedSize"] = struct["uncompressedSize"]
             self.callback(arg)
             self.callbackDoneEvent.set()
             return
@@ -102,7 +102,7 @@ class PVAPYProvider(QObject, NTNDA_Channel_Provider):
             return
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     app = QApplication(sys.argv)
     PVAPYProvider = PVAPYProvider()
     channelName = ""

--- a/Python/PY_NTNDA_Viewer/exampleStartP4P
+++ b/Python/PY_NTNDA_Viewer/exampleStartP4P
@@ -1,3 +1,2 @@
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/epics7/areaDetector/ADSupport/lib/linux-x86_64
-export EPICS_NTNDA_VIEWER_CHANNELNAME="13SIM1:Pva1:Image"
-python P4P_NTNDA_Viewer.py
+python P4P_NTNDA_Viewer.py 13SIM1:Pva1:Image

--- a/Python/PY_NTNDA_Viewer/exampleStartPVAPY
+++ b/Python/PY_NTNDA_Viewer/exampleStartPVAPY
@@ -1,3 +1,2 @@
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/epics7/areaDetector/ADSupport/lib/linux-x86_64
-export EPICS_NTNDA_VIEWER_CHANNELNAME="13SIM1:Pva1:Image"
-python PVAPY_NTNDA_Viewer.py
+python PVAPY_NTNDA_Viewer.py 13SIM1:Pva1:Image


### PR DESCRIPTION
No changes to functionality, I just made some adjustments to make it a bit easier to read.

To summarise, I have:
* reformatted the code to a more standard Python format
* removed the mix of single quotes and double quotes to be just just double quotes
* When checking for `None` use `is` not `==`
* Simplified some of the dictionary constructions
* Resized the GUI buttons
