### PR TITLE
Problem when pixarray created by Python code

### DIFF
--- a/Python/PY_NTNDA_Viewer/numpyImage.py
+++ b/Python/PY_NTNDA_Viewer/numpyImage.py
@@ -794,10 +794,7 @@ class NumpyImage(QWidget):
                 scalex = ratio * scalex
             elif ratio > 1.0:
                 scaley = scaley / ratio
-            qimage = qimage.scaled(scalex, scaley)
+            qimagescaled = qimage.scaled(scalex, scaley)
             painter = QPainter(self.caller)
-            painter.drawImage(0, 0, qimage)
-            while True:
-                if painter.end():
-                    break
-            self.image = None
+            painter.drawImage(0, 0, qimagescaled)
+


### PR DESCRIPTION
This is a change to fix a problem  I found in

 https://github.com/mrkraimer/testPython/tree/master/mandelbrot.DisplayImagePython.py 

It crashes with a segfault.

The crash does not happen if the pixarray is created in an IOC and obtained via either p4p or pvaPy.
The problem was in

    qimage = qimage.scaled(scalex, scaley)

changing it to

    qimagescaled = qimage.scaled(scalex, scaley)

fixes the problem

