### PR TITLE
Image j macros

### DIFF
--- a/ImageJ/EPICS_macros/CSS_epics.ijm
+++ b/ImageJ/EPICS_macros/CSS_epics.ijm
@@ -1,0 +1,1 @@
+run("EPICS AD Viewer");

--- a/ImageJ/EPICS_macros/CSS_epics_pva.ijm
+++ b/ImageJ/EPICS_macros/CSS_epics_pva.ijm
@@ -1,0 +1,1 @@
+run("EPICS NTNDA Viewer");

--- a/ImageJ/EPICS_macros/css_imagej.sh
+++ b/ImageJ/EPICS_macros/css_imagej.sh
@@ -1,0 +1,24 @@
+# EPICS_AD_Viewer macro
+# Authors
+#      Kaz Gofron, NSLS2
+#
+# Place 4 files in /usr/share/imagej/macros folder
+# Channel Access:
+#   CSS_epics.ijm
+#   css_imagej.sh
+# PV Access:
+#   CSS_epics_pva.ijm
+#   css_imagej_pva.sh
+#
+# From CSS/Phoebus/... call .sh script
+# Channel Access:
+#   /usr/share/imagej/macros/css_imagej.sh $(Sys)$(Dev)image1:
+# PV Access:
+#   /usr/share/imagej/macros/css_imagej_pva.sh $(Sys)$(Dev)Pva1:Image
+# which will start imagej viewer with populated PVs
+
+export EPICS_CA_MAX_ARRAY_BYTES=6000000
+cd ~
+rm EPICS_AD_Viewer.properties
+echo "PVPrefix=$1" > EPICS_AD_Viewer.properties
+imagej -m ~/.imagej/macros/CSS_epics.ijm

--- a/ImageJ/EPICS_macros/css_imagej_pva.sh
+++ b/ImageJ/EPICS_macros/css_imagej_pva.sh
@@ -1,0 +1,24 @@
+# EPICS_AD_Viewer macro
+# Authors
+#      Kaz Gofron, NSLS2
+#
+# Place 4 files in /usr/share/imagej/macros folder
+# Channel Access:
+#   CSS_epics.ijm
+#   css_imagej.sh
+# PV Access:
+#   CSS_epics_pva.ijm
+#   css_imagej_pva.sh
+#
+# From CSS/Phoebus/... call .sh script
+# Channel Access:
+#   /usr/share/imagej/macros/css_imagej.sh $(Sys)$(Dev)image1:
+# PV Access:
+#   /usr/share/imagej/macros/css_imagej_pva.sh $(Sys)$(Dev)Pva1:Image
+# which will start imagej viewer with populated PVs
+
+cd ~
+rm EPICS_NTNDA_Viewer.properties
+echo "channelName=$1" > EPICS_NTNDA_Viewer.properties
+imagej -m ~/.imagej/macros/CSS_epics_pva.ijm
+


### PR DESCRIPTION
At NSLS2 we find useful macros that populate PVs into the EPICS imagej viewers. 
Given that there are 100's of cameras and detectors at the NSLS2, this saves a lot of time. 
These scripts were developed for integration with CSS/Phoebus, but could be used/ expanded for use with other EPICS clients.
Installation requires copying 4 files into the ImageJ 'macros' folder.
```
# EPICS_AD_Viewer macro
#
# Place 4 files in /usr/share/imagej/macros folder
# Channel Access:
#   CSS_epics.ijm
#   css_imagej.sh
# PV Access:
#   CSS_epics_pva.ijm
#   css_imagej_pva.sh
#
# From CSS/Phoebus/... call .sh script
# Channel Access:
#   /usr/share/imagej/macros/css_imagej.sh $(Sys)$(Dev)image1:
# PV Access:
#   /usr/share/imagej/macros/css_imagej_pva.sh $(Sys)$(Dev)Pva1:Image
# which will start imagej viewer with populated PVs
```