### PR TITLE
Adds log checkbox to GUI

### DIFF
--- a/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -80,7 +80,6 @@ public class EPICS_AD_Viewer implements PlugIn
     boolean isNewStack;
     boolean isConnected;
     boolean isLogOn;
-   // boolean startedLog;
     volatile boolean isNewImageAvailable;
 
     javax.swing.Timer timer;
@@ -106,8 +105,7 @@ public class EPICS_AD_Viewer implements PlugIn
 
             if (isDebugFile)
             {
-                debugFile = new FileOutputStream(System.getProperty("user.home") +
-                        System.getProperty("file.separator") + "IJEPICS_debug.txt");
+                debugFile = new FileOutputStream(System.getProperty("user.home") + System.getProperty("file.separator") + "IJEPICS_debug.txt");
                 debugPrintStream = new PrintStream(debugFile);
             }
             javax.swing.SwingUtilities.invokeLater(
@@ -317,12 +315,12 @@ public class EPICS_AD_Viewer implements PlugIn
         try
         {
             connected = (ch_nx != null && ch_nx.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                    ch_ny != null && ch_ny.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                    ch_nz != null && ch_nz.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                    ch_colorMode != null && ch_colorMode.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                    ch_dataType != null && ch_dataType.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                    ch_image != null && ch_image.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                    ch_image_id != null && ch_image_id.getConnectionState() == Channel.ConnectionState.CONNECTED);
+                         ch_ny != null && ch_ny.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                         ch_nz != null && ch_nz.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                         ch_colorMode != null && ch_colorMode.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                         ch_dataType != null && ch_dataType.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                         ch_image != null && ch_image.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                         ch_image_id != null && ch_image_id.getConnectionState() == Channel.ConnectionState.CONNECTED);
             if (connected && !isConnected)
             {
                 isConnected = true;
@@ -830,23 +828,19 @@ public class EPICS_AD_Viewer implements PlugIn
         });
 
         captureCheckBox.addItemListener(new ItemListener()
-                                        {
-                                            public void itemStateChanged(ItemEvent e)
-                                            {
-                                                if (e.getStateChange() == ItemEvent.SELECTED)
-                                                {
-                                                    isSaveToStack = true;
-                                                    isNewStack = true;
-                                                    IJ.log("record on");
-                                                }
-                                                else
-                                                {
-                                                    isSaveToStack = false;
-                                                    IJ.log("record off");
-                                                }
+        {
+             public void itemStateChanged(ItemEvent e) {
+                 if (e.getStateChange() == ItemEvent.SELECTED) {
+                     isSaveToStack = true;
+                     isNewStack = true;
+                     IJ.log("record on");
+                 } else {
+                     isSaveToStack = false;
+                     IJ.log("record off");
+                 }
 
-                                            }
-                                        }
+             }
+        }
         );
 
     }

--- a/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -71,6 +71,7 @@ public class EPICS_AD_Viewer implements PlugIn
     JButton startButton;
     JButton stopButton;
     JButton snapButton;
+    JCheckBox logCheckBox;
 
     boolean isDebugMessages;
     boolean isDebugFile;
@@ -662,7 +663,7 @@ public class EPICS_AD_Viewer implements PlugIn
         stopButton.setEnabled(false);
         snapButton = new JButton("Snap");
         JCheckBox captureCheckBox = new JCheckBox("");
-        JCheckBox logCheckBox = new JCheckBox("");
+        logCheckBox = new JCheckBox("");
 
         frame = new JFrame("Image J EPICS_AD_Viewer Plugin");
         JPanel panel = new JPanel(new BorderLayout());

--- a/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_AD_Viewer.java
@@ -184,7 +184,11 @@ public class EPICS_AD_Viewer implements PlugIn
         ImageProcessor ip = img.getProcessor();
         if (ip == null) return;
         if(isLogOn) {
-            logMessage("turn off log to use Snap function", true, true);
+            ImageProcessor ipcopy = ip.duplicate();
+            ipcopy.setPixels(snapBackup);
+            ImagePlus imgcopy = new ImagePlus(PVPrefix + ":" + ArrayCounter, ipcopy);
+            resetContrast(imgcopy);
+            imgcopy.show();
         }
         else {
             ImagePlus imgcopy = new ImagePlus(PVPrefix + ":" + ArrayCounter, ip.duplicate());
@@ -323,12 +327,12 @@ public class EPICS_AD_Viewer implements PlugIn
         try
         {
             connected = (ch_nx != null && ch_nx.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                         ch_ny != null && ch_ny.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                         ch_nz != null && ch_nz.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                         ch_colorMode != null && ch_colorMode.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                         ch_dataType != null && ch_dataType.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                         ch_image != null && ch_image.getConnectionState() == Channel.ConnectionState.CONNECTED &&
-                         ch_image_id != null && ch_image_id.getConnectionState() == Channel.ConnectionState.CONNECTED);
+                    ch_ny != null && ch_ny.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                    ch_nz != null && ch_nz.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                    ch_colorMode != null && ch_colorMode.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                    ch_dataType != null && ch_dataType.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                    ch_image != null && ch_image.getConnectionState() == Channel.ConnectionState.CONNECTED &&
+                    ch_image_id != null && ch_image_id.getConnectionState() == Channel.ConnectionState.CONNECTED);
             if (connected && !isConnected)
             {
                 isConnected = true;
@@ -455,7 +459,7 @@ public class EPICS_AD_Viewer implements PlugIn
             {
                 imageStack = new ImageStack(img.getWidth(), img.getHeight());
                 imageStack.addSlice(PVPrefix + ArrayCounter, img.getProcessor());
-                // Note: we need to add this first slice twice in order to get the slider bar 
+                // Note: we need to add this first slice twice in order to get the slider bar
                 // on the window - ImageJ won't put it there if there is only 1 slice.
                 imageStack.addSlice(PVPrefix + ArrayCounter, img.getProcessor());
                 img.close();
@@ -734,7 +738,7 @@ public class EPICS_AD_Viewer implements PlugIn
         frame.setVisible(true);
 
 
-        int timerDelay = 2000;  // 2 seconds 
+        int timerDelay = 2000;  // 2 seconds
         timer = new javax.swing.Timer(timerDelay, new ActionListener()
         {
             public void actionPerformed(ActionEvent event)
@@ -852,19 +856,19 @@ public class EPICS_AD_Viewer implements PlugIn
         });
 
         captureCheckBox.addItemListener(new ItemListener()
-        {
-             public void itemStateChanged(ItemEvent e) {
-                 if (e.getStateChange() == ItemEvent.SELECTED) {
-                     isSaveToStack = true;
-                     isNewStack = true;
-                     IJ.log("record on");
-                 } else {
-                     isSaveToStack = false;
-                     IJ.log("record off");
-                 }
+                                        {
+                                            public void itemStateChanged(ItemEvent e) {
+                                                if (e.getStateChange() == ItemEvent.SELECTED) {
+                                                    isSaveToStack = true;
+                                                    isNewStack = true;
+                                                    IJ.log("record on");
+                                                } else {
+                                                    isSaveToStack = false;
+                                                    IJ.log("record off");
+                                                }
 
-             }
-        }
+                                            }
+                                        }
         );
 
     }
@@ -889,7 +893,7 @@ public class EPICS_AD_Viewer implements PlugIn
     }
     private void resetContrast(ImagePlus image){
         image.getProcessor().resetMinAndMax();
-        new ContrastEnhancer().stretchHistogram(img, 0.5);
+        new ContrastEnhancer().stretchHistogram(image, 0.51);
     }
     public class FrameExitListener extends WindowAdapter
     {

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -11,7 +11,6 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.geom.Arc2D;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
@@ -29,8 +28,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 
-import ij.gui.PlotWindow;
-import ij.plugin.frame.ContrastAdjuster;
 import org.epics.nt.NTNDArray;
 import org.epics.pvaClient.PvaClient;
 import org.epics.pvaClient.PvaClientChannel;
@@ -177,13 +174,13 @@ public class EPICS_NTNDA_Viewer
 
     private void disconnectPV() {
         try {
-            if (pvaClientChannel == null) {
+            if(pvaClientChannel == null) {
                 throw new RuntimeException("Channel already disconnected");
             }
             isChannelConnected = false;
-            if (isStarted) stopMonitor();
+            if(isStarted) stopMonitor();
             pvaClientChannel.destroy();
-            if (pvaClientMonitor != null) pvaClientMonitor.destroy();
+            if(pvaClientMonitor!=null) pvaClientMonitor.destroy();
             pvaClientChannel = null;
             pvaClientMonitor = null;
             logMessage("Disconnected from EPICS PV:" + channelName, true, true);
@@ -224,7 +221,7 @@ public class EPICS_NTNDA_Viewer
 
     private void handleEvents() {
         boolean gotEvent = pvaClientMonitor.poll();
-        if (!gotEvent) {
+        if(!gotEvent) {
             try {
                 Thread.sleep(1);
             } catch (Exception ex) {
@@ -232,11 +229,11 @@ public class EPICS_NTNDA_Viewer
             }
             return;
         }
-        while (gotEvent) {
+        while(gotEvent) {
             if (isDebugMessages) logMessage("calling updateImage", true, true);
             try {
                 boolean result = updateImage(pvaClientMonitor.getData());
-                if (!result) {
+                if(!result) {
                     logMessage("updateImage failed", true, true);
                     Thread.sleep(MS_WAIT);
                 }
@@ -269,8 +266,8 @@ public class EPICS_NTNDA_Viewer
             while (isPluginRunning) {
                 // A very short wait here lets stopMonitor run quickly when needed
                 Thread.sleep(1);
-                synchronized (this) {
-                    if (isStarted && pvaClientMonitor != null) {
+                synchronized(this) {
+                    if (isStarted && pvaClientMonitor!=null) {
                         handleEvents();
                     } else {
                         Thread.sleep(MS_WAIT);
@@ -287,7 +284,7 @@ public class EPICS_NTNDA_Viewer
             disconnectPV();
             timer.stop();
             writeProperties();
-            if (img != null) img.close();
+            if (img!=null) img.close();
             frame.setVisible(false);
             IJ.showStatus("Exiting Server");
 
@@ -368,25 +365,25 @@ public class EPICS_NTNDA_Viewer
                 break;
             }
         }
-        PVUnion pvUnionValue = pvs.getSubField(PVUnion.class, "value");
-        if (pvUnionValue == null) {
-            logMessage("value not found", true, true);
+        PVUnion pvUnionValue = pvs.getSubField(PVUnion.class,"value");
+        if (pvUnionValue==null) {
+            logMessage("value not found",true,true);
             return false;
         }
         PVScalarArray imagedata = pvUnionValue.get(PVScalarArray.class);
-        if (imagedata == null) {
-            logMessage("value is not a scalar array", true, true);
+        if (imagedata==null) {
+            logMessage("value is not a scalar array",true,true);
             return false;
         }
-        PVStructure pvCodecStruct = pvs.getSubField(PVStructure.class, "codec");
+        PVStructure pvCodecStruct = pvs.getSubField(PVStructure.class,"codec");
         PVString pvCodec = pvCodecStruct.getSubField(PVString.class, "name");
         String codec = pvCodec.get();
         if (!codec.isEmpty()) {
-            if (ntndCodec == null) {
+            if (ntndCodec==null) {
                 ntndCodec = new NTNDCodec();
             }
             NTNDArray ntndArray = NTNDArray.wrapUnsafe(pvs);
-            if (ntndArray == null) {
+            if (ntndArray==null) {
                 logMessage("value is not a valid NTNDArray", true, true);
                 return false;
             }
@@ -402,7 +399,7 @@ public class EPICS_NTNDA_Viewer
 
         int numElements = nx * ny * nz;
         if (numElements == 0) {
-            logMessage("array size = 0", true, true);
+            logMessage("array size = 0",true,true);
             return false;
         }
 
@@ -410,12 +407,13 @@ public class EPICS_NTNDA_Viewer
             logMessage("UpdateImage dt,dataType" + scalarType, true, true);
 
         if (isDebugMessages)
-            logMessage("UpdateImage cm,colorMode" + cm + " " + colorMode, true, true);
+            logMessage("UpdateImage cm,colorMode" + cm+ " "+colorMode, true, true);
 
 
         // if image size changes we must close window and make a new one.
         boolean makeNewWindow = false;
-        if (nx != imageSizeX || ny != imageSizeY || nz != imageSizeZ || cm != colorMode || scalarType != dataType) {
+        if (nx != imageSizeX || ny != imageSizeY || nz != imageSizeZ || cm != colorMode || scalarType != dataType)
+        {
             makeNewWindow = true;
             imageSizeX = nx;
             imageSizeY = ny;
@@ -429,35 +427,47 @@ public class EPICS_NTNDA_Viewer
 
         // If we are making a new stack close the window
         if (isNewStack) makeNewWindow = true;
-        if (img == null) makeNewWindow = true;
+        if(img==null) makeNewWindow = true;
 
         // If we need to make a new window then close the current one if it exists
-        if (img != null && makeNewWindow) {
-            try {
-                if (img.getWindow() == null || !img.getWindow().isClosed()) {
+        if (img != null && makeNewWindow)
+        {
+            try
+            {
+                if (img.getWindow() == null || !img.getWindow().isClosed())
+                {
                     ImageWindow win = img.getWindow();
                     if (win != null) {
                         oldWindowLocation = win.getLocationOnScreen();
                     }
                     img.close();
                 }
-            } catch (Exception ex) {
+            }
+            catch (Exception ex)
+            {
                 logMessage("Exception closing window " + ex.getMessage(), true, true);
             }
             makeNewWindow = false;
         }
         // If the window does not exist or is closed make a new one
         if (img == null || img.getWindow() == null || img.getWindow().isClosed()) {
-            switch (colorMode) {
+            switch (colorMode)
+            {
                 case 0:
                 case 1:
-                    if (dataType == ScalarType.pvUByte) {
+                    if (dataType == ScalarType.pvUByte)
+                    {
                         img = new ImagePlus(channelName, new ByteProcessor(imageSizeX, imageSizeY));
-                    } else if (dataType == ScalarType.pvUShort) {
+                    }
+                    else if (dataType == ScalarType.pvUShort)
+                    {
                         img = new ImagePlus(channelName, new ShortProcessor(imageSizeX, imageSizeY));
-                    } else if (dataType.isNumeric()) {
+                    }
+                    else if (dataType.isNumeric()) {
                         img = new ImagePlus(channelName, new FloatProcessor(imageSizeX, imageSizeY));
-                    } else {
+                    }
+                    else
+                    {
                         throw new RuntimeException("illegal array type " + dataType);
                     }
                     break;
@@ -476,7 +486,8 @@ public class EPICS_NTNDA_Viewer
             madeNewWindow = true;
         }
 
-        if (isNewStack) {
+        if (isNewStack)
+        {
             imageStack = new ImageStack(img.getWidth(), img.getHeight());
             imageStack.addSlice(channelName + numImageUpdates, img.getProcessor());
             // Note: we need to add this first slice twice in order to get the slider bar 
@@ -485,35 +496,43 @@ public class EPICS_NTNDA_Viewer
             img.close();
             img = new ImagePlus(channelName, imageStack);
             img.show();
-            logMessage("img.show() run", true, true);
             isNewStack = false;
         }
         imagedata = pvUnionValue.get(PVScalarArray.class);
-        if (imagedata == null) {
+        if(imagedata==null) {
             logMessage("value is not a scalar array", true, true);
             return false;
         }
 
-        if (colorMode == 0 || colorMode == 1) {
-            if (dataType == ScalarType.pvUByte) {
+        if (colorMode == 0 || colorMode == 1)
+        {
+            if (dataType == ScalarType.pvUByte)
+            {
                 byte[] pixels = new byte[numElements];
                 convert.toByteArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
-            } else if (dataType == ScalarType.pvUShort) {
+            }
+            else if (dataType == ScalarType.pvUShort)
+            {
                 short[] pixels = new short[numElements];
                 convert.toShortArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
-            } else if (dataType.isNumeric()) {
+            }
+            else if (dataType.isNumeric()) {
                 float[] pixels = new float[numElements];
                 convert.toFloatArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
-            } else {
+            }
+            else
+            {
                 throw new RuntimeException("illegal array type " + dataType);
             }
-        } else if (colorMode >= 2 && colorMode <= 4) {
+        }
+        else if (colorMode >= 2 && colorMode <= 4)
+        {
             int[] pixels = (int[]) img.getProcessor().getPixels();
 
-            byte inpixels[] = new byte[numElements];
+            byte inpixels[]=new byte[numElements];
 
             convert.toByteArray(imagedata, 0, numElements, inpixels, 0);
             double dispMin = img.getDisplayRangeMin();
@@ -524,30 +543,33 @@ public class EPICS_NTNDA_Viewer
                     // Recompute LUT
                     prevDispMin = dispMin;
                     prevDispMax = dispMax;
-                    double slope = 255 / (dispMax - dispMin);
-                    for (i = 0; i < 256; i++) {
-                        if (i < dispMin)
+                    double slope = 255/(dispMax - dispMin);
+                    for (i=0; i<256; i++) {
+                        if (i<dispMin)
                             colorLUT[i] = 0;
-                        else if (i > dispMax)
+                        else if (i>dispMax)
                             colorLUT[i] = (byte) 255;
                         else
-                            colorLUT[i] = (byte) ((i - dispMin) * slope + 0.5);
+                            colorLUT[i] = (byte)((i-dispMin)*slope + 0.5);
                     }
                 }
-                for (i = 0; i < numElements; i++) {
+                for (i=0; i<numElements; i++) {
                     inpixels[i] = colorLUT[inpixels[i] & 0xff];
                 }
             }
 
-            switch (colorMode) {
-                case 2: {
+            switch (colorMode)
+            {
+                case 2:
+                {
                     int in = 0, out = 0;
                     while (in < numElements) {
                         pixels[out++] = (inpixels[in++] & 0xFF) << 16 | (inpixels[in++] & 0xFF) << 8 | (inpixels[in++] & 0xFF);
                     }
                 }
                 break;
-                case 3: {
+                case 3:
+                {
                     int nCols = imageSizeX, nRows = imageSizeZ, row, col;
                     int redIn, greenIn, blueIn, out = 0;
                     for (row = 0; row < nRows; row++) {
@@ -560,7 +582,8 @@ public class EPICS_NTNDA_Viewer
                     }
                 }
                 break;
-                case 4: {
+                case 4:
+                {
                     int imageSize = imageSizeX * imageSizeY;
                     int redIn = 0, greenIn = imageSize, blueIn = 2 * imageSize, out = 0;
                     while (redIn < imageSize) {
@@ -579,16 +602,17 @@ public class EPICS_NTNDA_Viewer
             if(dataType!= ScalarType.pvUShort && dataType!=ScalarType.pvUByte) resetContrast(img);
         }
 
-        if (isSaveToStack) {
+        if (isSaveToStack)
+        {
             img.getStack().addSlice(channelName + numImageUpdates, img.getProcessor().duplicate());
         }
         img.setSlice(img.getNSlices());
         img.show();
         img.updateAndDraw();
         ImageCanvas ic = img.getCanvas();
-        Point loc = ic != null ? ic.getCursorLoc() : null;
-        if (loc != null)
-            img.mouseMoved(loc.x, loc.y);
+        Point loc = ic!=null ? ic.getCursorLoc() : null;
+        if (loc!=null)
+            img.mouseMoved(loc.x,loc.y);
         img.updateStatusbarValue();
         numImageUpdates++;
         // Automatically set brightness and contrast if we made a new window
@@ -601,7 +625,8 @@ public class EPICS_NTNDA_Viewer
      * this method should be invoked from the
      * event-dispatching thread.
      */
-    private void createAndShowGUI() {
+    private void createAndShowGUI()
+    {
         //Create and set up the window.
         nxText = new JTextField(6);
         nxText.setEditable(false);
@@ -694,13 +719,15 @@ public class EPICS_NTNDA_Viewer
         frame.setVisible(true);
 
         int timerDelay = 2000;  // 2 seconds 
-        timer = new javax.swing.Timer(timerDelay, new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
+        timer = new javax.swing.Timer(timerDelay, new ActionListener()
+        {
+            public void actionPerformed(ActionEvent event)
+            {
                 long time = new Date().getTime();
-                double elapsedTime = (double) (time - prevTime) / 1000.;
+                double elapsedTime = (double)(time - prevTime)/1000.;
                 double fps = numImageUpdates / elapsedTime;
                 NumberFormat form = DecimalFormat.getInstance();
-                ((DecimalFormat) form).applyPattern("0.0");
+                ((DecimalFormat)form).applyPattern("0.0");
                 fpsText.setText("" + form.format(fps));
                 if (isPluginRunning && isStarted && numImageUpdates > 0)
                     logMessage(String.format("Received %d images in %.2f sec", numImageUpdates, elapsedTime), true, false);
@@ -710,21 +737,27 @@ public class EPICS_NTNDA_Viewer
         });
         timer.start();
 
-        channelNameText.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
+        channelNameText.addActionListener(new ActionListener()
+        {
+            public void actionPerformed(ActionEvent event)
+            {
                 disconnectPV();
                 connectPV();
             }
         });
 
-        startButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
+        startButton.addActionListener(new ActionListener()
+        {
+            public void actionPerformed(ActionEvent event)
+            {
                 startDisplay();
             }
         });
 
-        stopButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
+        stopButton.addActionListener(new ActionListener()
+        {
+            public void actionPerformed(ActionEvent event)
+            {
                 stopDisplay();
             }
         });
@@ -783,19 +816,26 @@ public class EPICS_NTNDA_Viewer
             }
         });
 
-        snapButton.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent event) {
+        snapButton.addActionListener(new ActionListener()
+        {
+            public void actionPerformed(ActionEvent event)
+            {
                 makeImageCopy();
             }
         });
 
-        captureCheckBox.addItemListener(new ItemListener() {
-            public void itemStateChanged(ItemEvent e) {
-                if (e.getStateChange() == ItemEvent.SELECTED) {
+        captureCheckBox.addItemListener(new ItemListener()
+        {
+            public void itemStateChanged(ItemEvent e)
+            {
+                if (e.getStateChange() == ItemEvent.SELECTED)
+                {
                     isSaveToStack = true;
                     isNewStack = true;
                     logMessage("Capture on", true, true);
-                } else {
+                }
+                else
+                {
                     isSaveToStack = false;
                     logMessage("Capture off", true, true);
                 }
@@ -825,7 +865,8 @@ public class EPICS_NTNDA_Viewer
         }
     }
 
-    private void logMessage(String message, boolean logDisplay, boolean logFile) {
+    private void logMessage(String message, boolean logDisplay, boolean logFile)
+    {
         Date date = new Date();
         SimpleDateFormat simpleDate = new SimpleDateFormat("dd-MMM-yyyy kk:mm:ss.SSS");
         String completeMessage;
@@ -835,9 +876,11 @@ public class EPICS_NTNDA_Viewer
         if (logFile) IJ.log(completeMessage);
     }
 
-    private void readProperties() {
+    private void readProperties()
+    {
         String temp, path = null;
-        try {
+        try
+        {
             String fileSep = System.getProperty("file.separator");
             path = System.getProperty("user.home") + fileSep + propertyFile;
             FileInputStream file = new FileInputStream(path);
@@ -846,14 +889,17 @@ public class EPICS_NTNDA_Viewer
             temp = properties.getProperty("channelName");
             if (temp != null) channelName = temp;
             IJ.log("Read properties file: " + path + "  channelName= " + channelName);
-        } catch (Exception ex) {
+        } catch (Exception ex)
+        {
             IJ.log("readProperties:exception: " + ex.getMessage());
         }
     }
 
-    private void writeProperties() {
+    private void writeProperties()
+    {
         String path;
-        try {
+        try
+        {
             String fileSep = System.getProperty("file.separator");
             path = System.getProperty("user.home") + fileSep + propertyFile;
             properties.setProperty("channelName", channelName);
@@ -861,7 +907,8 @@ public class EPICS_NTNDA_Viewer
             properties.store(file, "EPICS_NTNDA_Viewer Properties");
             file.close();
             logMessage("Wrote properties file: " + path, true, true);
-        } catch (Exception ex) {
+        } catch (Exception ex)
+        {
             logMessage("writeProperties:exception: " + ex.getMessage(), true, true);
         }
     }

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -75,7 +75,7 @@ public class EPICS_NTNDA_Viewer
 
     private static final int QUEUE_SIZE = 1;
     private static final int MS_WAIT = 100;
-    private static PvaClient pva = PvaClient.get("pva");
+    private static PvaClient pva=PvaClient.get("pva");
     private static Convert convert = ConvertFactory.getConvert();
     private PvaClientChannel pvaClientChannel = null;
     private PvaClientMonitor pvaClientMonitor = null;
@@ -125,7 +125,8 @@ public class EPICS_NTNDA_Viewer
     /**
      * Constructor
      */
-    public EPICS_NTNDA_Viewer() {
+    public EPICS_NTNDA_Viewer()
+    {
         String temp = null;
         readProperties();
         temp = System.getenv("EPICS_NTNDA_VIEWER_CHANNELNAME");
@@ -140,47 +141,53 @@ public class EPICS_NTNDA_Viewer
      */
     public void channelStateChange(PvaClientChannel channel, boolean connected) {
         isChannelConnected = connected;
-        if (isChannelConnected) {
+        if(isChannelConnected) {
             channelNameText.setBackground(Color.green);
             logMessage("State changed to connected for " + channelName, true, true);
-            if (pvaClientMonitor == null) {
-                pvaClientMonitor = pvaClientChannel.createMonitor("record[queueSize=" + QUEUE_SIZE + "]field()");
+            if (pvaClientMonitor==null) {
+                pvaClientMonitor=pvaClientChannel.createMonitor("record[queueSize=" + QUEUE_SIZE + "]field()");
                 pvaClientMonitor.issueConnect();
             }
             if (startIsTrue) startMonitor();
-        } else if (pvaClientMonitor != null) {
+        } else if(pvaClientMonitor!=null) {
             channelNameText.setBackground(Color.red);
             logMessage("State changed to disconnected for " + channelName, true, true);
             numImageUpdates = 0;
         }
     }
 
-    private void connectPV() {
-        try {
+    private void connectPV()
+    {
+        try
+        {
             if (pvaClientChannel != null) {
                 throw new RuntimeException("Channel already connected");
             }
             channelName = channelNameText.getText();
             logMessage("Trying to connect to : " + channelName, true, true);
-            pvaClientChannel = pva.createChannel(channelName, "pva");
+            pvaClientChannel = pva.createChannel(channelName,"pva");
             pvaClientChannel.setStateChangeRequester(this);
             isChannelConnected = false;
             channelNameText.setBackground(Color.red);
             pvaClientChannel.issueConnect();
-        } catch (Exception ex) {
+        }
+        catch (Exception ex)
+        {
             logMessage("Could not connect to : " + channelName + " " + ex.getMessage(), true, false);
         }
     }
 
-    private void disconnectPV() {
-        try {
+    private void disconnectPV()
+    {
+        try
+        {
             if(pvaClientChannel == null) {
                 throw new RuntimeException("Channel already disconnected");
             }
             isChannelConnected = false;
             if(isStarted) stopMonitor();
             pvaClientChannel.destroy();
-            if(pvaClientMonitor!=null) pvaClientMonitor.destroy();
+            if(pvaClientMonitor!=null)  pvaClientMonitor.destroy();
             pvaClientChannel = null;
             pvaClientMonitor = null;
             logMessage("Disconnected from EPICS PV:" + channelName, true, true);
@@ -189,19 +196,22 @@ public class EPICS_NTNDA_Viewer
         }
     }
 
-    private void startMonitor() {
+    private void startMonitor()
+    {
         isStarted = true;
         pvaClientMonitor.start();
     }
 
-    private void stopMonitor() {
+    private void stopMonitor()
+    {
         synchronized (this) {
             pvaClientMonitor.stop();
             isStarted = false;
         }
     }
 
-    private void startDisplay() {
+    private void startDisplay()
+    {
         startButton.setEnabled(false);
         stopButton.setEnabled(true);
         snapButton.setEnabled(true);
@@ -210,7 +220,8 @@ public class EPICS_NTNDA_Viewer
         logMessage("Display started", true, false);
     }
 
-    private void stopDisplay() {
+    private void stopDisplay()
+    {
         startButton.setEnabled(true);
         stopButton.setEnabled(false);
         snapButton.setEnabled(false);
@@ -219,13 +230,14 @@ public class EPICS_NTNDA_Viewer
         logMessage("Display stopped", true, false);
     }
 
-    private void handleEvents() {
+    private void handleEvents()
+    {
         boolean gotEvent = pvaClientMonitor.poll();
         if(!gotEvent) {
             try {
                 Thread.sleep(1);
-            } catch (Exception ex) {
-                logMessage("Thread.sleep exception " + ex, true, true);
+            } catch(Exception ex) {
+                logMessage("Thread.sleep exception " + ex,true,true);
             }
             return;
         }
@@ -234,11 +246,11 @@ public class EPICS_NTNDA_Viewer
             try {
                 boolean result = updateImage(pvaClientMonitor.getData());
                 if(!result) {
-                    logMessage("updateImage failed", true, true);
+                    logMessage("updateImage failed",true,true);
                     Thread.sleep(MS_WAIT);
                 }
-            } catch (Exception ex) {
-                logMessage("handleEvents caught exception " + ex, true, true);
+            } catch(Exception ex) {
+                logMessage("handleEvents caught exception " + ex,true,true);
             }
             pvaClientMonitor.releaseEvent();
             // Break out of the loop if the display is stopped
@@ -250,20 +262,24 @@ public class EPICS_NTNDA_Viewer
     /* (non-Javadoc)
      * @see ij.plugin.PlugIn#run(java.lang.String)
      */
-    public void run(String arg) {
+    public void run(String arg)
+    {
         IJ.showStatus("epics running");
-        try {
+        try
+        {
             isPluginRunning = true;
             Date date = new Date();
             prevTime = date.getTime();
-            if (isDebugFile) {
+            if (isDebugFile)
+            {
                 debugFile = new FileOutputStream(System.getProperty("user.home") +
                         System.getProperty("file.separator") + "IJEPICS_debug.txt");
                 debugPrintStream = new PrintStream(debugFile);
             }
             stopDisplay();
             connectPV();
-            while (isPluginRunning) {
+            while (isPluginRunning)
+            {
                 // A very short wait here lets stopMonitor run quickly when needed
                 Thread.sleep(1);
                 synchronized(this) {
@@ -276,7 +292,8 @@ public class EPICS_NTNDA_Viewer
             } // isPluginRunning
 
             if (isDebugMessages) logMessage("run: Plugin stopping", true, true);
-            if (isDebugFile) {
+            if (isDebugFile)
+            {
                 debugPrintStream.close();
                 debugFile.close();
                 logMessage("Closed debug file", true, true);
@@ -284,26 +301,31 @@ public class EPICS_NTNDA_Viewer
             disconnectPV();
             timer.stop();
             writeProperties();
-            if (img!=null) img.close();
+            if(img!=null) img.close();
             frame.setVisible(false);
             IJ.showStatus("Exiting Server");
 
-        } catch (Exception e) {
+        }
+        catch (Exception e)
+        {
             logMessage("run: Got exception: " + e.getMessage(), true, true);
             e.printStackTrace();
             logMessage("Close EPICS_NTNDA_Viewer window, and reopen, try again", true, true);
             IJ.showStatus(e.toString());
-            try {
-                if (isDebugFile) {
+            try
+            {
+                if (isDebugFile)
+                {
                     debugPrintStream.close();
                     debugFile.close();
                 }
-            } catch (Exception ee) {
             }
+            catch (Exception ee) { }
         }
     }
 
-    private void makeImageCopy() {
+    private void makeImageCopy()
+    {
         ImageProcessor ip = img.getProcessor();
         if (ip == null) return;
         ImagePlus imgcopy = new ImagePlus(channelName + ":" + numImageUpdates, ip.duplicate());
@@ -311,28 +333,29 @@ public class EPICS_NTNDA_Viewer
     }
 
 
-    private boolean updateImage(PvaClientMonitorData monitorData) {
+    private boolean updateImage(PvaClientMonitorData monitorData)
+    {
         Point oldWindowLocation = null;
         boolean madeNewWindow = false;
         PVStructure pvs = monitorData.getPVStructure();
         PVStructureArray dimArray = pvs.getSubField(PVStructureArray.class, "dimension");
-        if (dimArray == null) {
+        if(dimArray==null) {
             logMessage("dimension not found", true, true);
             return false;
         }
         int ndim = dimArray.getLength();
-        if (ndim < 1) {
+        if(ndim<1) {
             logMessage("dimension is empty", true, true);
             return false;
         }
         int dimsint[] = new int[ndim];
-        StructureArrayData dimdata = new StructureArrayData();
-        dimArray.get(0, ndim, dimdata);
-        for (int i = 0; i < ndim; ++i) {
+        StructureArrayData dimdata=new StructureArrayData();
+        dimArray.get(0,ndim,dimdata);
+        for(int i=0; i<ndim; ++i) {
             PVStructure dim = (PVStructure) dimdata.data[i];
-            PVInt pvLen = dim.getSubField(PVInt.class, "size");
-            if (pvLen == null) {
-                logMessage("dimension size not found", true, true);
+            PVInt pvLen=dim.getSubField(PVInt.class,"size");
+            if(pvLen == null) {
+                logMessage("dimension size not found",true,true);
                 return false;
             }
             dimsint[i] = pvLen.get();
@@ -340,24 +363,25 @@ public class EPICS_NTNDA_Viewer
         int nx = dimsint[0];
         int ny = dimsint[1];
         int nz = 1;
-        if (ndim >= 3)
+        if (ndim>=3)
             nz = dimsint[2];
         int cm = 0;
         PVStructureArray attrArray = pvs.getSubField(PVStructureArray.class, "attribute");
-        if (attrArray != null) {
+        if(attrArray!=null) {
             int nattr = attrArray.getLength();
             StructureArrayData attrdata = new StructureArrayData();
             attrArray.get(0, nattr, attrdata);
-            for (int i = 0; i < nattr; i++) {
+            for (int i = 0; i < nattr; i++)
+            {
                 PVStructure pvAttr = attrdata.data[i];
-                PVString pvName = pvAttr.getSubField(PVString.class, "name");
-                if (pvName == null) continue;
+                PVString pvName = pvAttr.getSubField(PVString.class,"name");
+                if(pvName==null) continue;
                 String name = pvName.get();
-                if (!name.equals("ColorMode")) continue;
+                if(!name.equals("ColorMode")) continue;
                 PVUnion pvUnion = pvAttr.getSubField(PVUnion.class, "value");
-                if (pvUnion == null) continue;
+                if(pvUnion==null) continue;
                 PVScalar pvcm = pvUnion.get(PVScalar.class);
-                if (pvcm == null) {
+                if(pvcm==null) {
                     logMessage("color mode is not a PVScalar", true, true);
                     continue;
                 }
@@ -366,12 +390,12 @@ public class EPICS_NTNDA_Viewer
             }
         }
         PVUnion pvUnionValue = pvs.getSubField(PVUnion.class,"value");
-        if (pvUnionValue==null) {
+        if(pvUnionValue==null) {
             logMessage("value not found",true,true);
             return false;
         }
         PVScalarArray imagedata = pvUnionValue.get(PVScalarArray.class);
-        if (imagedata==null) {
+        if(imagedata==null) {
             logMessage("value is not a scalar array",true,true);
             return false;
         }
@@ -379,12 +403,12 @@ public class EPICS_NTNDA_Viewer
         PVString pvCodec = pvCodecStruct.getSubField(PVString.class, "name");
         String codec = pvCodec.get();
         if (!codec.isEmpty()) {
-            if (ntndCodec==null) {
+            if(ntndCodec==null) {
                 ntndCodec = new NTNDCodec();
             }
             NTNDArray ntndArray = NTNDArray.wrapUnsafe(pvs);
-            if (ntndArray==null) {
-                logMessage("value is not a valid NTNDArray", true, true);
+            if(ntndArray==null) {
+                logMessage("value is not a valid NTNDArray",true,true);
                 return false;
             }
             ntndCodec.decompress(ntndArray);
@@ -395,7 +419,7 @@ public class EPICS_NTNDA_Viewer
         if (ny == 0) ny = 1;  // 1-D images which are OK, useful with dynamic profiler
 
         if (isDebugMessages)
-            logMessage("UpdateImage: got image, sizes: " + nx + " " + ny + " " + nz, true, true);
+            logMessage("UpdateImage: got image, sizes: " + nx + " " + ny + " " + nz,true,true);
 
         int numElements = nx * ny * nz;
         if (numElements == 0) {
@@ -412,7 +436,7 @@ public class EPICS_NTNDA_Viewer
 
         // if image size changes we must close window and make a new one.
         boolean makeNewWindow = false;
-        if (nx != imageSizeX || ny != imageSizeY || nz != imageSizeZ || cm != colorMode || scalarType != dataType)
+        if (nx != imageSizeX || ny != imageSizeY || nz != imageSizeZ || cm != colorMode || scalarType !=dataType)
         {
             makeNewWindow = true;
             imageSizeX = nx;
@@ -430,7 +454,7 @@ public class EPICS_NTNDA_Viewer
         if(img==null) makeNewWindow = true;
 
         // If we need to make a new window then close the current one if it exists
-        if (img != null && makeNewWindow)
+        if (img!=null && makeNewWindow)
         {
             try
             {
@@ -443,14 +467,14 @@ public class EPICS_NTNDA_Viewer
                     img.close();
                 }
             }
-            catch (Exception ex)
-            {
+            catch (Exception ex) {
                 logMessage("Exception closing window " + ex.getMessage(), true, true);
             }
             makeNewWindow = false;
         }
         // If the window does not exist or is closed make a new one
-        if (img == null || img.getWindow() == null || img.getWindow().isClosed()) {
+        if (img == null || img.getWindow() == null || img.getWindow().isClosed())
+        {
             switch (colorMode)
             {
                 case 0:
@@ -500,37 +524,33 @@ public class EPICS_NTNDA_Viewer
         }
         imagedata = pvUnionValue.get(PVScalarArray.class);
         if(imagedata==null) {
-            logMessage("value is not a scalar array", true, true);
+            logMessage("value is not a scalar array",true,true);
             return false;
         }
 
         if (colorMode == 0 || colorMode == 1)
         {
-            if (dataType == ScalarType.pvUByte)
-            {
+            if (dataType == ScalarType.pvUByte) {
                 byte[] pixels = new byte[numElements];
                 convert.toByteArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
             }
-            else if (dataType == ScalarType.pvUShort)
-            {
+            else if (dataType == ScalarType.pvUShort) {
                 short[] pixels = new short[numElements];
                 convert.toShortArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
             }
             else if (dataType.isNumeric()) {
-                float[] pixels = new float[numElements];
+                float[] pixels =new float[numElements];
                 convert.toFloatArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
-            }
-            else
-            {
+            } else {
                 throw new RuntimeException("illegal array type " + dataType);
             }
         }
         else if (colorMode >= 2 && colorMode <= 4)
         {
-            int[] pixels = (int[]) img.getProcessor().getPixels();
+            int[] pixels = (int[])img.getProcessor().getPixels();
 
             byte inpixels[]=new byte[numElements];
 
@@ -548,7 +568,7 @@ public class EPICS_NTNDA_Viewer
                         if (i<dispMin)
                             colorLUT[i] = 0;
                         else if (i>dispMax)
-                            colorLUT[i] = (byte) 255;
+                            colorLUT[i] = (byte)255;
                         else
                             colorLUT[i] = (byte)((i-dispMin)*slope + 0.5);
                     }
@@ -859,7 +879,8 @@ public class EPICS_NTNDA_Viewer
         public void windowClosing(WindowEvent event) {
             isPluginRunning = false;
             // We need to wake up the main thread so it shuts down cleanly
-            synchronized (this) {
+            synchronized (this)
+            {
                 notify();
             }
         }
@@ -889,7 +910,8 @@ public class EPICS_NTNDA_Viewer
             temp = properties.getProperty("channelName");
             if (temp != null) channelName = temp;
             IJ.log("Read properties file: " + path + "  channelName= " + channelName);
-        } catch (Exception ex)
+        }
+        catch (Exception ex)
         {
             IJ.log("readProperties:exception: " + ex.getMessage());
         }
@@ -912,4 +934,4 @@ public class EPICS_NTNDA_Viewer
             logMessage("writeProperties:exception: " + ex.getMessage(), true, true);
         }
     }
-}
+ }

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -327,7 +327,11 @@ public class EPICS_NTNDA_Viewer
         ImageProcessor ip = img.getProcessor();
         if (ip == null) return;
         if(isLogOn) {
-            logMessage("turn off log to use Snap function", true, true);
+            ImageProcessor ipcopy = ip.duplicate();
+            ipcopy.setPixels(snapBackup);
+            ImagePlus imgcopy = new ImagePlus(channelName + ":" + numImageUpdates, ipcopy);
+            resetContrast(imgcopy);
+            imgcopy.show();
         }
         else {
             ImagePlus imgcopy = new ImagePlus(channelName + ":" + numImageUpdates, ip.duplicate());
@@ -619,7 +623,7 @@ public class EPICS_NTNDA_Viewer
         }
 
         /*Takes log of image, stores snapshot for Undo if plugin is stopped.
-        */
+         */
         if (isLogOn) {
             img.getProcessor().snapshot();
             snapBackup=img.getProcessor().getSnapshotPixels();
@@ -965,4 +969,4 @@ public class EPICS_NTNDA_Viewer
             logMessage("writeProperties:exception: " + ex.getMessage(), true, true);
         }
     }
- }
+}

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -28,9 +28,6 @@ import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.border.EmptyBorder;
 
-import com.sun.corba.se.pept.transport.ByteBufferPool;
-import ij.*;
-import ij.process.*;
 import org.epics.nt.NTNDArray;
 import org.epics.pvaClient.PvaClient;
 import org.epics.pvaClient.PvaClientChannel;
@@ -49,6 +46,8 @@ import org.epics.pvdata.pv.PVUnion;
 import org.epics.pvdata.pv.ScalarType;
 import org.epics.pvdata.pv.StructureArrayData;
 
+import ij.*;
+import ij.process.*;
 import ij.gui.ImageWindow;
 import ij.gui.ImageCanvas;
 import ij.plugin.ContrastEnhancer;
@@ -116,6 +115,7 @@ public class EPICS_NTNDA_Viewer
     private JButton startButton = null;
     private JButton stopButton = null;
     private JButton snapButton = null;
+    private JCheckBox logCheckBox = null;
 
     private javax.swing.Timer timer = null;
 
@@ -679,7 +679,7 @@ public class EPICS_NTNDA_Viewer
         stopButton = new JButton("Stop");
         snapButton = new JButton("Snap");
         JCheckBox captureCheckBox = new JCheckBox("");
-        JCheckBox logCheckBox = new JCheckBox("");
+        logCheckBox = new JCheckBox("");
 
         frame = new JFrame("Image J EPICS_NTNDA_Viewer Plugin");
         JPanel panel = new JPanel(new BorderLayout());

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -127,7 +127,7 @@ public class EPICS_NTNDA_Viewer
      */
     public EPICS_NTNDA_Viewer()
     {
-        String temp = null;
+        String temp=null;
         readProperties();
         temp = System.getenv("EPICS_NTNDA_VIEWER_CHANNELNAME");
         if (temp != null) {
@@ -144,7 +144,7 @@ public class EPICS_NTNDA_Viewer
         if(isChannelConnected) {
             channelNameText.setBackground(Color.green);
             logMessage("State changed to connected for " + channelName, true, true);
-            if (pvaClientMonitor==null) {
+            if(pvaClientMonitor==null) {
                 pvaClientMonitor=pvaClientChannel.createMonitor("record[queueSize=" + QUEUE_SIZE + "]field()");
                 pvaClientMonitor.issueConnect();
             }
@@ -181,7 +181,7 @@ public class EPICS_NTNDA_Viewer
     {
         try
         {
-            if(pvaClientChannel == null) {
+            if(pvaClientChannel==null) {
                 throw new RuntimeException("Channel already disconnected");
             }
             isChannelConnected = false;
@@ -191,7 +191,8 @@ public class EPICS_NTNDA_Viewer
             pvaClientChannel = null;
             pvaClientMonitor = null;
             logMessage("Disconnected from EPICS PV:" + channelName, true, true);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             logMessage("Cannot disconnect from EPICS PV:" + channelName + ex.getMessage(), true, true);
         }
     }
@@ -204,7 +205,7 @@ public class EPICS_NTNDA_Viewer
 
     private void stopMonitor()
     {
-        synchronized (this) {
+        synchronized(this) {
             pvaClientMonitor.stop();
             isStarted = false;
         }
@@ -335,26 +336,26 @@ public class EPICS_NTNDA_Viewer
 
     private boolean updateImage(PvaClientMonitorData monitorData)
     {
-        Point oldWindowLocation = null;
+        Point oldWindowLocation =null;
         boolean madeNewWindow = false;
         PVStructure pvs = monitorData.getPVStructure();
-        PVStructureArray dimArray = pvs.getSubField(PVStructureArray.class, "dimension");
+        PVStructureArray dimArray = pvs.getSubField(PVStructureArray.class,"dimension");
         if(dimArray==null) {
-            logMessage("dimension not found", true, true);
+            logMessage("dimension not found",true,true);
             return false;
         }
         int ndim = dimArray.getLength();
         if(ndim<1) {
-            logMessage("dimension is empty", true, true);
+            logMessage("dimension is empty",true,true);
             return false;
         }
         int dimsint[] = new int[ndim];
         StructureArrayData dimdata=new StructureArrayData();
         dimArray.get(0,ndim,dimdata);
         for(int i=0; i<ndim; ++i) {
-            PVStructure dim = (PVStructure) dimdata.data[i];
-            PVInt pvLen=dim.getSubField(PVInt.class,"size");
-            if(pvLen == null) {
+            PVStructure dim = (PVStructure)dimdata.data[i];
+            PVInt pvLen = dim.getSubField(PVInt.class,"size");
+            if(pvLen==null) {
                 logMessage("dimension size not found",true,true);
                 return false;
             }
@@ -366,23 +367,23 @@ public class EPICS_NTNDA_Viewer
         if (ndim>=3)
             nz = dimsint[2];
         int cm = 0;
-        PVStructureArray attrArray = pvs.getSubField(PVStructureArray.class, "attribute");
+        PVStructureArray attrArray = pvs.getSubField(PVStructureArray.class,"attribute");
         if(attrArray!=null) {
             int nattr = attrArray.getLength();
-            StructureArrayData attrdata = new StructureArrayData();
-            attrArray.get(0, nattr, attrdata);
-            for (int i = 0; i < nattr; i++)
+            StructureArrayData attrdata=new StructureArrayData();
+            attrArray.get(0,nattr,attrdata);
+            for (int i = 0; i<nattr; i++)
             {
                 PVStructure pvAttr = attrdata.data[i];
                 PVString pvName = pvAttr.getSubField(PVString.class,"name");
                 if(pvName==null) continue;
                 String name = pvName.get();
                 if(!name.equals("ColorMode")) continue;
-                PVUnion pvUnion = pvAttr.getSubField(PVUnion.class, "value");
+                PVUnion pvUnion = pvAttr.getSubField(PVUnion.class,"value");
                 if(pvUnion==null) continue;
                 PVScalar pvcm = pvUnion.get(PVScalar.class);
                 if(pvcm==null) {
-                    logMessage("color mode is not a PVScalar", true, true);
+                    logMessage("color mode is not a PVScalar",true,true);
                     continue;
                 }
                 cm = ConvertFactory.getConvert().toInt(pvcm);
@@ -473,7 +474,7 @@ public class EPICS_NTNDA_Viewer
             makeNewWindow = false;
         }
         // If the window does not exist or is closed make a new one
-        if (img == null || img.getWindow() == null || img.getWindow().isClosed())
+        if (img==null || img.getWindow() == null || img.getWindow().isClosed())
         {
             switch (colorMode)
             {
@@ -530,12 +531,12 @@ public class EPICS_NTNDA_Viewer
 
         if (colorMode == 0 || colorMode == 1)
         {
-            if (dataType == ScalarType.pvUByte) {
-                byte[] pixels = new byte[numElements];
+            if(dataType==ScalarType.pvUByte) {
+                byte[] pixels= new byte[numElements];
                 convert.toByteArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
             }
-            else if (dataType == ScalarType.pvUShort) {
+            else if(dataType==ScalarType.pvUShort) {
                 short[] pixels = new short[numElements];
                 convert.toShortArray(imagedata, 0, numElements, pixels, 0);
                 img.getProcessor().setPixels(pixels);
@@ -929,7 +930,8 @@ public class EPICS_NTNDA_Viewer
             properties.store(file, "EPICS_NTNDA_Viewer Properties");
             file.close();
             logMessage("Wrote properties file: " + path, true, true);
-        } catch (Exception ex)
+        }
+        catch (Exception ex)
         {
             logMessage("writeProperties:exception: " + ex.getMessage(), true, true);
         }


### PR DESCRIPTION
Log Checkbox is added on both EPICS_NTNDA_Viewer and EPICS_AD_Viewer. Selecting it takes log of the image, unchecking undoes it/turns it off.
 ![logbox](https://user-images.githubusercontent.com/106117997/176743641-e7567483-f928-4f72-ab10-70d4ee2b337b.png)
 
![logboxAD](https://user-images.githubusercontent.com/106117997/176743758-0fb68082-3ea8-4ebd-9969-d1a46ec8ffdc.png)

 Log checkbox uses built in ImageJ log function:
* For 8-bit, new pixel value = log(pixelValue) * 255/log(255).
* For 16-bit, new pixel value = log(pixelValue) * maxPixelValue/log(maxPixelValue), where maxPixelValue is the value of the maximum pixel value currently displayed. 

* For 32-bit, new pixel value = log(pixelValue). Plugin sets contrast to make new pixel values/image viewable.

Once the plugin is running/has been started, selecting another separate image in ImageJ (a Snap or other) and selecting the log checkbox will take the log of that image, according to the same rules above, and unchecking will undo the log. 

**Known Bugs/Cautions**
Care must be taken when switching between taking the log of two different images. It is best to turn log off before switching between images, to avoid taking the log of an image twice on accident. 

The log checkbox does not work well when attempting to turn the log display of individual slices of a stack on and off. 

log checkbox by request of @antoninomiceli