### PR TITLE
Use path object so file separator is not needed, default to install p…

### DIFF
--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -20,7 +20,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
@@ -837,6 +836,7 @@ public class EPICS_NTNDA_Viewer
         Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
+            // If the .config directory does not exist, move back up to the home dir
             if (!Files.exists(path)){
                 path = path.getParent();
             }
@@ -860,6 +860,7 @@ public class EPICS_NTNDA_Viewer
         Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
+            // If the .config directory does not exist, move back up to the home dir
             if (!Files.exists(path)){
                 path = path.getParent();
             }

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -19,6 +19,10 @@ import java.awt.event.WindowEvent;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -829,17 +833,21 @@ public class EPICS_NTNDA_Viewer
 
     private void readProperties()
     {
-        String temp, path = null;
+        String temp = null;
+        Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
-            String fileSep = System.getProperty("file.separator");
-            path = System.getProperty("user.home") + fileSep + propertyFile;
-            FileInputStream file = new FileInputStream(path);
+            if (!Files.exists(path)){
+                path = path.getParent();
+            }
+            path = Paths.get(path.toString(), propertyFile);
+
+            FileInputStream file = new FileInputStream(path.toString());
             properties.load(file);
             file.close();
             temp = properties.getProperty("channelName");
             if (temp != null) channelName = temp;
-            IJ.log("Read properties file: " + path + "  channelName= " + channelName);
+            IJ.log("Read properties file: " + path.toString() + "  channelName= " + channelName);
         }
         catch (Exception ex)
         {
@@ -849,16 +857,19 @@ public class EPICS_NTNDA_Viewer
 
     private void writeProperties()
     {
-        String path;
+        Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
-            String fileSep = System.getProperty("file.separator");
-            path = System.getProperty("user.home") + fileSep + propertyFile;
+            if (!Files.exists(path)){
+                path = path.getParent();
+            }
+            path = Paths.get(path.toString(), propertyFile);
+
             properties.setProperty("channelName", channelName);
-            FileOutputStream file = new FileOutputStream(path);
+            FileOutputStream file = new FileOutputStream(path.toString());
             properties.store(file, "EPICS_NTNDA_Viewer Properties");
             file.close();
-            logMessage("Wrote properties file: " + path, true, true);
+            logMessage("Wrote properties file: " + path.toString(), true, true);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
…roperty file in .config

Currently, the imagej NTNDA viewer will create the properties file in the home directory. It would be preferable if this was created in the `.config` folder instead.