### PR TITLE
Update 3D plot axis creation in NumpyImage class

### DIFF
--- a/Python/PY_NTNDA_Viewer/numpyImage.py
+++ b/Python/PY_NTNDA_Viewer/numpyImage.py
@@ -371,7 +371,7 @@ class NumpyImage(QWidget):
             image = image[yoffset:ny, xoffset:nx]
             image = np.transpose(image)
             fig = plt.figure()
-            ax = fig.gca(projection="3d")
+            ax = fig.add_subplot(111, projection="3d")
             ax.set_xlabel("x")
             ax.set_ylabel("y")
             ax.set_zlabel("value")


### PR DESCRIPTION

## Problem
`ax = fig.gca(projection="3d")` got deprecated in newer `matplotlib` versions, and gave the following error:

<img width="718" height="101" alt="image" src="https://github.com/user-attachments/assets/394464f4-451b-4ba2-9c4a-e2ffa4330929" />


## Fix

using `fig.add_subplot(111, projection="3d")` works fine:
<img width="1476" height="835" alt="image" src="https://github.com/user-attachments/assets/31175bbe-24e8-4f74-a089-986329e3e7e8" />

Tested on python 3.10 and matplotlib 3.10.3 for `PVAPY_NTNDA_Viewer.py` and `P4P_NTNDA_Viewer.py`. 