### PR TITLE
Add lz4hdf5 codec support

### DIFF
--- a/ImageJ/EPICS_areaDetector/NTNDCodec.java
+++ b/ImageJ/EPICS_areaDetector/NTNDCodec.java
@@ -1,6 +1,6 @@
 // NTNDCodec.java
 //
-// Decompresses NTNDrrays that are compressed with Blosc, JPEG, LZ4, or Bitshuffle/LZ4.
+// Decompresses NTNDrrays that are compressed with Blosc, JPEG, LZ4, LZ4HDF5, or Bitshuffle/LZ4.
 // Original authors
 //      Marty Kraimer
 //      Mark Rivers
@@ -123,6 +123,8 @@ public class NTNDCodec
             }
         } else if (codecName.equals("lz4")) {
             decompressLZ4Dll.LZ4_decompress_fast(decompressInBuffer, decompressOutBuffer, new NativeLong(uncompressedSize));
+        } else if (codecName.equals("lz4hdf5")) {
+            decompressLZ4HDF5Dll.decompress_lz4hdf5(decompressInBuffer, decompressOutBuffer, new NativeLong(uncompressedSize));
         } else if (codecName.equals("bslz4")) {
             int blockSize=0;
             int elemSize;

--- a/ImageJ/EPICS_areaDetector/decompressLZ4HDF5Dll.java
+++ b/ImageJ/EPICS_areaDetector/decompressLZ4HDF5Dll.java
@@ -1,0 +1,20 @@
+import java.nio.Buffer;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+
+public class decompressLZ4HDF5Dll {
+
+	static {
+		Native.register("lz4hdf5" + getArchPlatform());
+	}
+
+	public static String getArchPlatform() {
+		String archDataModel = System.getProperty("sun.arch.data.model");
+		if (archDataModel.equals("64")) {
+			archDataModel = "";
+		}
+		return archDataModel;
+	}
+
+	public static native void decompress_lz4hdf5(Buffer src, Buffer dest, NativeLong destSize);
+}


### PR DESCRIPTION
This adds support for decompressing NTNDArrays that are compressed with the lz4hdf5 codec.