### PR TITLE
Add zlib decompression for imagej and python viewers

### DIFF
--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -20,7 +20,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
@@ -837,6 +836,7 @@ public class EPICS_NTNDA_Viewer
         Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
+            // If the .config directory does not exist, move back up to the home dir
             if (!Files.exists(path)){
                 path = path.getParent();
             }
@@ -860,6 +860,7 @@ public class EPICS_NTNDA_Viewer
         Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
+            // If the .config directory does not exist, move back up to the home dir
             if (!Files.exists(path)){
                 path = path.getParent();
             }

--- a/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
+++ b/ImageJ/EPICS_areaDetector/EPICS_NTNDA_Viewer.java
@@ -19,6 +19,10 @@ import java.awt.event.WindowEvent;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -829,17 +833,21 @@ public class EPICS_NTNDA_Viewer
 
     private void readProperties()
     {
-        String temp, path = null;
+        String temp = null;
+        Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
-            String fileSep = System.getProperty("file.separator");
-            path = System.getProperty("user.home") + fileSep + propertyFile;
-            FileInputStream file = new FileInputStream(path);
+            if (!Files.exists(path)){
+                path = path.getParent();
+            }
+            path = Paths.get(path.toString(), propertyFile);
+
+            FileInputStream file = new FileInputStream(path.toString());
             properties.load(file);
             file.close();
             temp = properties.getProperty("channelName");
             if (temp != null) channelName = temp;
-            IJ.log("Read properties file: " + path + "  channelName= " + channelName);
+            IJ.log("Read properties file: " + path.toString() + "  channelName= " + channelName);
         }
         catch (Exception ex)
         {
@@ -849,16 +857,19 @@ public class EPICS_NTNDA_Viewer
 
     private void writeProperties()
     {
-        String path;
+        Path path = Paths.get(System.getProperty("user.home"), ".config");
         try
         {
-            String fileSep = System.getProperty("file.separator");
-            path = System.getProperty("user.home") + fileSep + propertyFile;
+            if (!Files.exists(path)){
+                path = path.getParent();
+            }
+            path = Paths.get(path.toString(), propertyFile);
+
             properties.setProperty("channelName", channelName);
-            FileOutputStream file = new FileOutputStream(path);
+            FileOutputStream file = new FileOutputStream(path.toString());
             properties.store(file, "EPICS_NTNDA_Viewer Properties");
             file.close();
-            logMessage("Wrote properties file: " + path, true, true);
+            logMessage("Wrote properties file: " + path.toString(), true, true);
         }
         catch (Exception ex)
         {

--- a/ImageJ/EPICS_areaDetector/NTNDCodec.java
+++ b/ImageJ/EPICS_areaDetector/NTNDCodec.java
@@ -1,6 +1,6 @@
 // NTNDCodec.java
 //
-// Decompresses NTNDrrays that are compressed with Blosc, JPEG, LZ4, or Bitshuffle/LZ4.
+// Decompresses NTNDrrays that are compressed with Blosc, JPEG, LZ4, Bitshuffle/LZ4, or zlib.
 // Original authors
 //      Marty Kraimer
 //      Mark Rivers
@@ -27,6 +27,7 @@ import org.epics.pvdata.pv.PVUnion;
 import org.epics.pvdata.pv.ScalarType;
 
 import com.sun.jna.NativeLong;
+import com.sun.jna.ptr.NativeLongByReference;
 
 /**
  * Codec processor for an NTNDArray
@@ -145,6 +146,13 @@ public class NTNDCodec
             }
             decompressBSLZ4Dll.bshuf_decompress_lz4(decompressInBuffer, decompressOutBuffer, new NativeLong(uncompressedSize/elemSize), 
                                      new NativeLong(elemSize), new NativeLong(blockSize));
+        } else if (codecName.equals("zlib")) {
+            NativeLongByReference destLen = new NativeLongByReference(new NativeLong(uncompressedSize));
+            int status = decompressZlibDll.uncompress(decompressOutBuffer, destLen, decompressInBuffer, new NativeLong(compressedSize));
+            if (status != 0) {
+                message = "zlib uncompress returned status="+status;
+                return false;
+            }
         } else {
             message = "Unknown compression=" +codecName
                    + " compressedSize=" + compressedSize 

--- a/ImageJ/EPICS_areaDetector/decompressZlibDll.java
+++ b/ImageJ/EPICS_areaDetector/decompressZlibDll.java
@@ -1,0 +1,25 @@
+import java.nio.Buffer;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.ptr.NativeLongByReference;
+
+public class decompressZlibDll {
+
+	static {
+		try {
+			Native.register("z" + getArchPlatform());
+		} catch (UnsatisfiedLinkError e) {
+			Native.register("zlib" + getArchPlatform());
+		}
+	}
+
+	public static String getArchPlatform() {
+		String archDataModel = System.getProperty("sun.arch.data.model");
+		if (archDataModel.equals("64")) {
+			archDataModel = "";
+		}
+		return archDataModel;
+	}
+
+	public static native int uncompress(Buffer dest, NativeLongByReference destLen, Buffer src, NativeLong srcLen);
+}

--- a/Python/PY_NTNDA_Viewer/codecAD.py
+++ b/Python/PY_NTNDA_Viewer/codecAD.py
@@ -202,6 +202,10 @@ class CodecAD:
             lib = self.__findLibrary("decompressJPEG")
         elif self.__codecName == "lz4" or self.__codecName == "bslz4":
             lib = self.__findLibrary("bitshuffle")
+        elif self.__codecName == "zlib":
+            lib = self.__findLibrary("z")
+            if lib is None:
+                lib = self.__findLibrary("zlib")
         else:
             lib = None
         if lib == None:
@@ -245,6 +249,18 @@ class CodecAD:
             )
             data = np.array(outarray)
             data = data.flatten()
+        elif self.__codecName == "zlib":
+            destLen = ctypes.c_ulong(uncompressed)
+            status = lib.uncompress(
+                out_char_array.from_buffer(outarray),
+                ctypes.byref(destLen),
+                in_char_array.from_buffer(inarray),
+                compressed,
+            )
+            if status != 0:
+                raise Exception("zlib uncompress returned status=" + str(status))
+            data = np.array(outarray)
+            data = np.frombuffer(data, dtype=dtype)
         else:
             raise Exception(self.__codecName + " is unsupported codec")
         self.__compressRatio = round(float(uncompressed / compressed))

--- a/docs/ADViewers/ImageJ_EPICS_NTNDA_Viewer.rst
+++ b/docs/ADViewers/ImageJ_EPICS_NTNDA_Viewer.rst
@@ -64,8 +64,10 @@ To use this ImageJ plugin do the following:
       native Java code for jpeg decompression is signifcantly more
       complicated (and probably slower) than just using the C library.
       The required libraries on Linux are ``decompressJPEG.so``, ``libjpeg.so``,
-      ``libblosc.so``, and ``libzlib.so``. On Windows the libraries are
-      ``decompressJPEG.dll``, ``jpeg.dll``, ``blosc.dll``, and ``zlib.dll``.
+      ``libblosc.so``, ``libz.so`` (or ``libzlib.so``), and ``libbitshuffle.so``.
+      On Windows the libraries are
+      ``decompressJPEG.dll``, ``jpeg.dll``, ``blosc.dll``, ``zlib.dll``,
+      and ``bitshuffle.dll``.
    -  These libraries can all be built as part of
       ``areaDetector/ADSupport``, and this is recommended. If the ImageJ
       viewers are being installed at a location which is not building


### PR DESCRIPTION
Need to test with proper detector setup.

- **Use path object so file separator is not needed, default to install property file in .config**
- **Remove unused import**
- **Add zlib decompression option for imagej and python viewers**
